### PR TITLE
5.4 fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -144,3 +144,15 @@ Broken Outlines
 
 # TODO (1.052)
 - Fix the unfinish Glow/Bloom Transfer (glow through transparency)
+
+## Version 1.054
+### Fixes
+- Repaired Existing Features
+- Could not repair censorship correctly
+- Now defaults to uncensored until a solution is made.
+- Natlan characters seem to be functional, didn't test all cases.
+
+### Known issues
+- Some transparencies will not work properly as the characters load in.
+- This also affects custom outline colors, will look for a solution. (LOD Shaders)
+- Intel Integrated graphics glow effects are still malfunctioning, will look into it.

--- a/Config.ini
+++ b/Config.ini
@@ -8,7 +8,7 @@ namespace = TexFx
 
 [Constants]
 ; Set to 0/1/2 to make the default Uncensor ON/OFF/MODIFIED
-global $uncensor = 2
+global $uncensor = 0
 
 ;Set to 0/1 to Disable/Enable "Animated RGB" Effects (May cause unexpected bright flashing lights).
 global $seizure = 1

--- a/DISABLED_Includes.ini
+++ b/DISABLED_Includes.ini
@@ -4,6 +4,8 @@
 include = Config.ini
 [Include Main]
 include = Main.ini
+
+; If DISABLED_Keybindings.ini, rename it then enable this.
 ; [Include Keybindings]
 ; include = Keybindings.ini
 
@@ -17,8 +19,12 @@ include = hic_sunt_dracones\ComponentFriendlyBuiltinShaders.ini
 
 [Include hic_sunt_dracones\TransparencyDiffusePixelShaderRegex]
 include = hic_sunt_dracones\DiffusePixelShaderRegex.ini
+[Include hic_sunt_dracones\TransparencyDiffusePixelShaderRegex53]
+include = hic_sunt_dracones\DiffusePixelShaderRegex53.ini
 [Include hic_sunt_dracones\TransparencyOutlinePixelShaderRegex]
 include = hic_sunt_dracones\OutlinePixelShaderRegex.ini
 [Include hic_sunt_dracones\TransparencyDiffuse2SidedRegex]
 include = hic_sunt_dracones\Diffuse2SidedRegex.ini
+[Include hic_sunt_dracones\TransparencyDiffuse2SidedRegex53]
+include = hic_sunt_dracones\Diffuse2SidedRegex53.ini
 

--- a/DISABLED_Includes.ini
+++ b/DISABLED_Includes.ini
@@ -23,6 +23,8 @@ include = hic_sunt_dracones\DiffusePixelShaderRegex.ini
 include = hic_sunt_dracones\DiffusePixelShaderRegex53.ini
 [Include hic_sunt_dracones\TransparencyOutlinePixelShaderRegex]
 include = hic_sunt_dracones\OutlinePixelShaderRegex.ini
+[Include hic_sunt_dracones\TransparencyOutlinePixelShaderRegex53]
+include = hic_sunt_dracones\OutlinePixelShaderRegex53.ini
 [Include hic_sunt_dracones\TransparencyDiffuse2SidedRegex]
 include = hic_sunt_dracones\Diffuse2SidedRegex.ini
 [Include hic_sunt_dracones\TransparencyDiffuse2SidedRegex53]

--- a/hic_sunt_dracones/ComponentFriendlyBuiltinShaders.ini
+++ b/hic_sunt_dracones/ComponentFriendlyBuiltinShaders.ini
@@ -17,18 +17,20 @@ run = CommandListSetInstanceValues
 if $ps//1 == 037730 && $ps != 037730.1 && $texfx_on
     run = CommandListHullHack
     run = CommandListSetResourceReferences
-    if $ps == 037730.553
+    if $ps == 037730.555
+        if !$hull_hack_val
+            run = CustomShaderComponent.0
+        else
+            run = CustomShaderComponentSupressHH.0
+        endif
+    elif $ps == 037730.533
         if !$hull_hack_val
             run = CustomShaderComponent.0_5_3
         else
             run = CustomShaderComponentSupressHH.0_5_3
         endif
     else
-        if !$hull_hack_val
-            run = CustomShaderComponent.0
-        else
-            run = CustomShaderComponentSupressHH.0
-        endif
+        run = CustomShaderDrawOpaque
     endif
 ;else
     ;drawindexed = $_1, $_2, 0
@@ -47,7 +49,38 @@ run = CommandListSetInstanceValues
 if $ps//1 == 037730 && $ps != 037730.1 && $texfx_on
     run = CommandListHullHack
     run = CommandListSetResourceReferences
-    if $ps == 037730.553
+    if $ps == 037730.555
+        if !$hull_hack_val
+            ;if orfix installed
+            if $ps//1 == 037730 && $ps != 037730.1
+                ;x101 = x70
+                if x70//1 == 037730
+                    ;w103 = 24000 + 1
+                    run = CustomShaderComponent.0
+                else
+                    ;w103 = 24000 + 2
+                    run = CustomShaderComponent.1
+                endif
+            else
+                ;w103 = 24000 + 3
+                run = CustomShaderComponent.1
+            endif
+        else
+            if $ps//1 == 037730.0 && $ps != 037730.1
+                ;x101 = x70
+                if x70//1 == 037730
+                    ;w103 = 24000 + 4
+                    run = CustomShaderComponentSupressHH.0
+                else
+                    ;w103 = 24000 + 5
+                    run = CustomShaderComponentSupressHH.1
+                endif
+            else
+                ;w103 = 24000 + 6
+                run = CustomShaderComponentSupressHH.1
+            endif
+        endif
+    elif $ps == 037730.533
         if !$hull_hack_val
             ;if orfix installed
             if $ps//1 == 037730 && $ps != 037730.1
@@ -79,36 +112,7 @@ if $ps//1 == 037730 && $ps != 037730.1 && $texfx_on
             endif
         endif
     else
-        if !$hull_hack_val
-            ;if orfix installed
-            if $ps//1 == 037730 && $ps != 037730.1
-                ;x101 = x70
-                if x70//1 == 037730
-                    ;w103 = 24000 + 1
-                    run = CustomShaderComponent.0
-                else
-                    ;w103 = 24000 + 2
-                    run = CustomShaderComponent.1
-                endif
-            else
-                ;w103 = 24000 + 3
-                run = CustomShaderComponent.1
-            endif
-        else
-            if $ps//1 == 037730.0 && $ps != 037730.1
-                ;x101 = x70
-                if x70//1 == 037730
-                    ;w103 = 24000 + 4
-                    run = CustomShaderComponentSupressHH.0
-                else
-                    ;w103 = 24000 + 5
-                    run = CustomShaderComponentSupressHH.1
-                endif
-            else
-                ;w103 = 24000 + 6
-                run = CustomShaderComponentSupressHH.1
-            endif
-        endif
+        run = CustomShaderDrawOpaque
     endif
 ;else
     ;drawindexed = $_1, $_2, 0
@@ -271,4 +275,9 @@ handling = skip
 cull = none
 run = CommandList\TexFx\HullHack
 ps = NatlanOutlineWithDiffuseColor0.hlsl
+drawindexed = $_1, $_2, 0
+
+[CustomShaderDrawOpaque]
+handling = skip
+cull = none
 drawindexed = $_1, $_2, 0

--- a/hic_sunt_dracones/ComponentFriendlyBuiltinShaders.ini
+++ b/hic_sunt_dracones/ComponentFriendlyBuiltinShaders.ini
@@ -145,7 +145,7 @@ run = CommandListClearInstanceValues
 handling = skip
 cull = none
 run = CommandList\TexFx\HullHack
-vs = OutlineHull.hlsl
+;vs = OutlineHull.hlsl
 ps = OutlineWithDiffuseColor0.hlsl
 drawindexed = $_1, $_2, 0
 
@@ -160,7 +160,7 @@ drawindexed = $_1, $_2, 0
 handling = skip
 cull = none
 run = CommandList\TexFx\HullHack
-vs = OutlineHull.hlsl
+;vs = OutlineHull.hlsl
 ps = OutlineWithDiffuseColor1.hlsl
 drawindexed = $_1, $_2, 0
 
@@ -169,6 +169,37 @@ handling = skip
 cull = none
 run = CommandList\TexFx\HullHack
 ps = OutlineWithDiffuseColor1.hlsl
+drawindexed = $_1, $_2, 0
+
+; Default Component Shaders
+[CustomShaderComponent_5_3.0]
+handling = skip
+cull = none
+run = CommandList\TexFx\HullHack
+vs = OutlineHull_5_3.hlsl
+ps = OutlineWithDiffuseColor0_5_3.hlsl
+drawindexed = $_1, $_2, 0
+
+[CustomShaderComponentSupressHH_5_3.0]
+handling = skip
+cull = none
+run = CommandList\TexFx\HullHack
+ps = OutlineWithDiffuseColor0_5_3.hlsl
+drawindexed = $_1, $_2, 0
+
+[CustomShaderComponent_5_3.1]
+handling = skip
+cull = none
+run = CommandList\TexFx\HullHack
+vs = OutlineHull_5_3.hlsl
+ps = OutlineWithDiffuseColor1_5_3.hlsl
+drawindexed = $_1, $_2, 0
+
+[CustomShaderComponentSupressHH_5_3.1]
+handling = skip
+cull = none
+run = CommandList\TexFx\HullHack
+ps = OutlineWithDiffuseColor1_5_3.hlsl
 drawindexed = $_1, $_2, 0
 
 [CustomShaderComponentNatlan.0]

--- a/hic_sunt_dracones/ComponentFriendlyBuiltinShaders.ini
+++ b/hic_sunt_dracones/ComponentFriendlyBuiltinShaders.ini
@@ -17,10 +17,18 @@ run = CommandListSetInstanceValues
 if $ps//1 == 037730 && $ps != 037730.1 && $texfx_on
     run = CommandListHullHack
     run = CommandListSetResourceReferences
-    if !$hull_hack_val
-        run = CustomShaderComponent.0
+    if $ps == 037730.553
+        if !$hull_hack_val
+            run = CustomShaderComponent.0_5_3
+        else
+            run = CustomShaderComponentSupressHH.0_5_3
+        endif
     else
-        run = CustomShaderComponentSupressHH.0
+        if !$hull_hack_val
+            run = CustomShaderComponent.0
+        else
+            run = CustomShaderComponentSupressHH.0
+        endif
     endif
 ;else
     ;drawindexed = $_1, $_2, 0
@@ -39,34 +47,67 @@ run = CommandListSetInstanceValues
 if $ps//1 == 037730 && $ps != 037730.1 && $texfx_on
     run = CommandListHullHack
     run = CommandListSetResourceReferences
-    if !$hull_hack_val
-        ;if orfix installed
-        if $ps//1 == 037730 && $ps != 037730.1
-            ;x101 = x70
-            if x70//1 == 037730
-                ;w103 = 24000 + 1
-                run = CustomShaderComponent.0
+    if $ps == 037730.553
+        if !$hull_hack_val
+            ;if orfix installed
+            if $ps//1 == 037730 && $ps != 037730.1
+                ;x101 = x70
+                if x70//1 == 037730
+                    ;w103 = 24000 + 1
+                    run = CustomShaderComponent.0_5_3
+                else
+                    ;w103 = 24000 + 2
+                    run = CustomShaderComponent.1_5_3
+                endif
             else
-                ;w103 = 24000 + 2
+                ;w103 = 24000 + 3
+                run = CustomShaderComponent.1_5_3
+            endif
+        else
+            if $ps//1 == 037730.0 && $ps != 037730.1
+                ;x101 = x70
+                if x70//1 == 037730
+                    ;w103 = 24000 + 4
+                    run = CustomShaderComponentSupressHH.0_5_3
+                else
+                    ;w103 = 24000 + 5
+                    run = CustomShaderComponentSupressHH.1_5_3
+                endif
+            else
+                ;w103 = 24000 + 6
+                run = CustomShaderComponentSupressHH.1_5_3
+            endif
+        endif
+    else
+        if !$hull_hack_val
+            ;if orfix installed
+            if $ps//1 == 037730 && $ps != 037730.1
+                ;x101 = x70
+                if x70//1 == 037730
+                    ;w103 = 24000 + 1
+                    run = CustomShaderComponent.0
+                else
+                    ;w103 = 24000 + 2
+                    run = CustomShaderComponent.1
+                endif
+            else
+                ;w103 = 24000 + 3
                 run = CustomShaderComponent.1
             endif
         else
-            ;w103 = 24000 + 3
-            run = CustomShaderComponent.1
-        endif
-    else
-        if $ps//1 == 037730.0 && $ps != 037730.1
-            ;x101 = x70
-            if x70//1 == 037730
-                ;w103 = 24000 + 4
-                run = CustomShaderComponentSupressHH.0
+            if $ps//1 == 037730.0 && $ps != 037730.1
+                ;x101 = x70
+                if x70//1 == 037730
+                    ;w103 = 24000 + 4
+                    run = CustomShaderComponentSupressHH.0
+                else
+                    ;w103 = 24000 + 5
+                    run = CustomShaderComponentSupressHH.1
+                endif
             else
-                ;w103 = 24000 + 5
+                ;w103 = 24000 + 6
                 run = CustomShaderComponentSupressHH.1
             endif
-        else
-            ;w103 = 24000 + 6
-            run = CustomShaderComponentSupressHH.1
         endif
     endif
 ;else
@@ -145,7 +186,7 @@ run = CommandListClearInstanceValues
 handling = skip
 cull = none
 run = CommandList\TexFx\HullHack
-;vs = OutlineHull.hlsl
+vs = OutlineHull.hlsl
 ps = OutlineWithDiffuseColor0.hlsl
 drawindexed = $_1, $_2, 0
 
@@ -160,7 +201,7 @@ drawindexed = $_1, $_2, 0
 handling = skip
 cull = none
 run = CommandList\TexFx\HullHack
-;vs = OutlineHull.hlsl
+vs = OutlineHull.hlsl
 ps = OutlineWithDiffuseColor1.hlsl
 drawindexed = $_1, $_2, 0
 
@@ -172,7 +213,7 @@ ps = OutlineWithDiffuseColor1.hlsl
 drawindexed = $_1, $_2, 0
 
 ; Default Component Shaders
-[CustomShaderComponent_5_3.0]
+[CustomShaderComponent.0_5_3]
 handling = skip
 cull = none
 run = CommandList\TexFx\HullHack
@@ -180,14 +221,14 @@ vs = OutlineHull_5_3.hlsl
 ps = OutlineWithDiffuseColor0_5_3.hlsl
 drawindexed = $_1, $_2, 0
 
-[CustomShaderComponentSupressHH_5_3.0]
+[CustomShaderComponentSupressHH.0_5_3]
 handling = skip
 cull = none
 run = CommandList\TexFx\HullHack
 ps = OutlineWithDiffuseColor0_5_3.hlsl
 drawindexed = $_1, $_2, 0
 
-[CustomShaderComponent_5_3.1]
+[CustomShaderComponent.1_5_3]
 handling = skip
 cull = none
 run = CommandList\TexFx\HullHack
@@ -195,7 +236,7 @@ vs = OutlineHull_5_3.hlsl
 ps = OutlineWithDiffuseColor1_5_3.hlsl
 drawindexed = $_1, $_2, 0
 
-[CustomShaderComponentSupressHH_5_3.1]
+[CustomShaderComponentSupressHH.1_5_3]
 handling = skip
 cull = none
 run = CommandList\TexFx\HullHack

--- a/hic_sunt_dracones/DefaultCustomShader.ini
+++ b/hic_sunt_dracones/DefaultCustomShader.ini
@@ -40,21 +40,20 @@ elif $vs == 5.0 || $vs == 5.1
 		else
 			run = CustomShaderTransparencyNatlanSupressHH.0
 		endif
-	endif
-	if $use_default_shader == 1 || $use_default_shader == 3
+	elif $use_default_shader == 1 || $use_default_shader == 3
 		$use_default_shader = -1
 		if $ps//1 == 037730 && $ps != 037730.1
 			if x70//1 == 037730
 				if !$hull_hack_val
-					run = CustomShaderTransparencyNatlan.0
-				else
-					run = CustomShaderTransparencyNatlanSupressHH.0
-				endif
-			else
-				if !$hull_hack_val
 					run = CustomShaderTransparencyNatlan.1
 				else
 					run = CustomShaderTransparencyNatlanSupressHH.1
+				endif
+			else
+				if !$hull_hack_val
+					run = CustomShaderTransparencyNatlan.0
+				else
+					run = CustomShaderTransparencyNatlanSupressHH.0
 				endif
 			endif
 		else
@@ -112,15 +111,15 @@ else
 		if $ps//1 == 037730 && $ps != 037730.1
 			if x70//1 == 037730
 				if !$hull_hack_val
-					run = CustomShaderTransparencyNatlan.0
-				else
-					run = CustomShaderTransparencyNatlanSupressHH.0
-				endif
-			else
-				if !$hull_hack_val
 					run = CustomShaderTransparencyNatlan.1
 				else
 					run = CustomShaderTransparencyNatlanSupressHH.1
+				endif
+			else
+				if !$hull_hack_val
+					run = CustomShaderTransparencyNatlan.0
+				else
+					run = CustomShaderTransparencyNatlanSupressHH.0
 				endif
 			endif
 		else
@@ -163,6 +162,21 @@ filter_index = 5.1
 hash = 0f925c97398336cd
 allow_duplicate_hash = overrule
 filter_index = 5.1
+
+; [ShaderOverrideOutline_5.3_NatlanPath 1 VS]
+; hash = 8893da57ca38888e
+; allow_duplicate_hash = overrule
+; filter_index = 5.3
+
+; [ShaderOverrideOutline_5.3_NatlanPath 2 VS]
+; hash = 5af681e49bdf4db4
+; allow_duplicate_hash = overrule
+; filter_index = 5.3
+
+; [ShaderOverrideOutline_5.3_NatlanPath LQ VS]
+; hash = 
+; allow_duplicate_hash = overrule
+; filter_index = 5.3
 
 [CustomShaderTransparencyDefault.0_3.4]
 handling = skip
@@ -221,7 +235,7 @@ drawindexed = auto
 [CustomShaderTransparencyDefault.0]
 handling = skip
 cull = none
-vs = OutlineHull.hlsl
+;vs = OutlineHull.hlsl
 ps = OutlineWithDiffuseColor0.hlsl
 drawindexed = auto
 
@@ -234,7 +248,7 @@ drawindexed = auto
 [CustomShaderTransparencyDefault.1]
 handling = skip
 cull = none
-vs = OutlineHull.hlsl
+;vs = OutlineHull.hlsl
 ps = OutlineWithDiffuseColor1.hlsl
 drawindexed = auto
 
@@ -242,4 +256,30 @@ drawindexed = auto
 handling = skip
 cull = none
 ps = OutlineWithDiffuseColor1.hlsl
+drawindexed = auto
+
+[CustomShaderTransparencyDefault_5_3.0]
+handling = skip
+cull = none
+vs = OutlineHull_5_3.hlsl
+ps = OutlineWithDiffuseColor0_5_3.hlsl
+drawindexed = auto
+
+[CustomShaderTransparencySupressHH_5_3.0]
+handling = skip
+cull = none
+ps = OutlineWithDiffuseColor0_5_3.hlsl
+drawindexed = auto
+
+[CustomShaderTransparencyDefault_5_3.1]
+handling = skip
+cull = none
+vs = OutlineHull_5_3.hlsl
+ps = OutlineWithDiffuseColor1_5_3.hlsl
+drawindexed = auto
+
+[CustomShaderTransparencySupressHH_5_3.1]
+handling = skip
+cull = none
+ps = OutlineWithDiffuseColor1_5_3.hlsl
 drawindexed = auto

--- a/hic_sunt_dracones/DefaultCustomShader.ini
+++ b/hic_sunt_dracones/DefaultCustomShader.ini
@@ -258,28 +258,160 @@ cull = none
 ps = OutlineWithDiffuseColor1.hlsl
 drawindexed = auto
 
-[CustomShaderTransparencyDefault_5_3.0]
+[CustomShaderTransparencyDefault.0_5_3]
 handling = skip
 cull = none
 vs = OutlineHull_5_3.hlsl
 ps = OutlineWithDiffuseColor0_5_3.hlsl
 drawindexed = auto
 
-[CustomShaderTransparencySupressHH_5_3.0]
+[CustomShaderTransparencySupressHH.0_5_3]
 handling = skip
 cull = none
 ps = OutlineWithDiffuseColor0_5_3.hlsl
 drawindexed = auto
 
-[CustomShaderTransparencyDefault_5_3.1]
+[CustomShaderTransparencyDefault.1_5_3]
 handling = skip
 cull = none
 vs = OutlineHull_5_3.hlsl
 ps = OutlineWithDiffuseColor1_5_3.hlsl
 drawindexed = auto
 
-[CustomShaderTransparencySupressHH_5_3.1]
+[CustomShaderTransparencySupressHH.1_5_3]
 handling = skip
 cull = none
 ps = OutlineWithDiffuseColor1_5_3.hlsl
 drawindexed = auto
+
+[CommandListSwapVersion53]
+local $ps = ps
+local $vs = vs
+run = CommandListHullHack
+run = CommandListSetInstanceValues
+run = CommandListSetResourceReferences
+if $vs == 3.4
+    if $use_default_shader == 0
+		$use_default_shader = -1
+		run = CustomShaderTransparencyDefault.0_3.4
+	endif
+	if $use_default_shader == 1
+		$use_default_shader = -1
+		if $ps == 037730.0
+			run = CustomShaderTransparencyDefault.0_3.4
+		else
+			run = CustomShaderTransparencyDefault.1_3.4
+		endif
+	endif
+elif $vs == 4.5
+    if $use_default_shader == 0
+		$use_default_shader = -1
+		run = CustomShaderTransparencyDefault.0_4.5
+	endif
+	if $use_default_shader == 1
+		$use_default_shader = -1
+		if $ps == 037730.0
+			run = CustomShaderTransparencyDefault.0_4.5
+		else
+			run = CustomShaderTransparencyDefault.1_4.5
+		endif
+	endif
+elif $vs == 5.0 || $vs == 5.1
+    if $use_default_shader == 0 || $use_default_shader == 2
+		$use_default_shader = -1
+		if !$hull_hack_val
+			run = CustomShaderTransparencyNatlan.0
+		else
+			run = CustomShaderTransparencyNatlanSupressHH.0
+		endif
+	elif $use_default_shader == 1 || $use_default_shader == 3
+		$use_default_shader = -1
+		if $ps//1 == 037730 && $ps != 037730.1
+			if x70//1 == 037730
+				if !$hull_hack_val
+					run = CustomShaderTransparencyNatlan.1
+				else
+					run = CustomShaderTransparencyNatlanSupressHH.1
+				endif
+			else
+				if !$hull_hack_val
+					run = CustomShaderTransparencyNatlan.0
+				else
+					run = CustomShaderTransparencyNatlanSupressHH.0
+				endif
+			endif
+		else
+			if !$hull_hack_val
+				run = CustomShaderTransparencyNatlan.1
+			else
+				run = CustomShaderTransparencyNatlanSupressHH.1
+			endif
+		endif
+	endif
+else
+;Whatever the current version is, default to this.
+    if $use_default_shader == 0
+		$use_default_shader = -1
+		if !$hull_hack_val
+			run = CustomShaderTransparencyDefault.0_5_3
+		else
+			run = CustomShaderTransparencySupressHH.0_5_3
+		endif
+	endif
+	if $use_default_shader == 1
+		$use_default_shader = -1
+		if $ps//1 == 037730 && $ps != 037730.1
+			if x70//1 == 037730
+				if !$hull_hack_val
+					run = CustomShaderTransparencyDefault.0_5_3
+				else
+					run = CustomShaderTransparencySupressHH.0_5_3
+				endif
+			else
+				if !$hull_hack_val
+					run = CustomShaderTransparencyDefault.1_5_3
+				else
+					run = CustomShaderTransparencySupressHH.1_5_3
+				endif
+			endif
+		else
+			if !$hull_hack_val
+				run = CustomShaderTransparencyDefault.1_5_3
+			else
+				run = CustomShaderTransparencySupressHH.1_5_3
+			endif
+		endif
+	endif
+    if $use_default_shader == 2
+		$use_default_shader = -1
+		if !$hull_hack_val
+			run = CustomShaderTransparencyNatlan.0
+		else
+			run = CustomShaderTransparencyNatlanSupressHH.0
+		endif
+	endif
+	if $use_default_shader == 3
+		$use_default_shader = -1
+		if $ps//1 == 037730 && $ps != 037730.1
+			if x70//1 == 037730
+				if !$hull_hack_val
+					run = CustomShaderTransparencyNatlan.1
+				else
+					run = CustomShaderTransparencyNatlanSupressHH.1
+				endif
+			else
+				if !$hull_hack_val
+					run = CustomShaderTransparencyNatlan.0
+				else
+					run = CustomShaderTransparencyNatlanSupressHH.0
+				endif
+			endif
+		else
+			if !$hull_hack_val
+				run = CustomShaderTransparencyNatlan.1
+			else
+				run = CustomShaderTransparencyNatlanSupressHH.1
+			endif
+		endif
+	endif
+endif

--- a/hic_sunt_dracones/Diffuse2SidedRegex.ini
+++ b/hic_sunt_dracones/Diffuse2SidedRegex.ini
@@ -86,7 +86,7 @@ if_z ${ini}.y\n
 ; \t\t    mov ${dim}.zw, l(0,0)\n
 ; \t\t    ftoi ${dim}.xyyy, ${dim}.xyyy\n
 ; \t\t    ld_indexable(texture2d)(float,float,float,float) ${tex69}.xyzw, ${dim}.xyzy, t69.xyzw\n
-\t\t    sample_indexable(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
+\t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 \t\t    mul ${tex69}.yz, ${tex69}.yz, ${ini}.yz\n
 \t\t    add_sat ${tex69}.yz, ${tex69}.yx, ${storage}.wx\n
 ; Alpha Channel

--- a/hic_sunt_dracones/Diffuse2SidedRegex.ini
+++ b/hic_sunt_dracones/Diffuse2SidedRegex.ini
@@ -42,11 +42,11 @@ dcl_output o5\.x\n
 ^\s+add -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n
 ^\s+lt -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n.*)
 (?P<TillTexcord>sample_[b_]{0,2}indexable\(texture2d\)\(float,float,float,float\) r\d\d?\.[xyzw]+, (?P<TexcoordX>r\d\d?.(xyxx|yzyy)), t[01].[xyzw]+, s\d(, \w\d+(\.[xyzw]+)?)?$)
-(?P<TillGlow>.*sqrt o1\.w, (?<Glow>r\d+\.[xyzw]+))
-;(?<Tillo2CBPick>.*cb0\[(?<cb0o2pick>\d+)\].[xyzw]+, l\(0.00392156886\))
-(?<Tillo2Pick>.*movc o2\.z, (?<o2Pick>r\d\.[xyzw]+, r\d\.[xyzw]+, r\d\.[xyzw]+))
-(?P<Tillo1>.*mov o1\.xyz, (?<o1var>r\d+\.[xyzw]+))
-(?P<Tillo2>.*mov o2\.(?<o2var>[xyw]+, r\d\.[xyzw]+))
+; (?P<TillGlow>.*sqrt o1\.w, (?<Glow>r\d+\.[xyzw]+))
+; ;(?<Tillo2CBPick>.*cb0\[(?<cb0o2pick>\d+)\].[xyzw]+, l\(0.00392156886\))
+; (?<Tillo2Pick>.*movc o2\.z, (?<o2Pick>r\d\.[xyzw]+, r\d\.[xyzw]+, r\d\.[xyzw]+))
+(?P<Tillo1>.*mov o1\.(?<o1var>[xyzw]{4}, r\d\.[xyzw]+))
+(?P<Tillo2>.*mov o2\.(?<o2var>[xyzw]+, r\d\.[xyzw]+))
 (?P<TillBloom>.*mov o4.x, (?<Bloom>r\d+\.[xyzw]+))
 (?P<TillRet>.*)
 ret
@@ -62,16 +62,17 @@ ${MatchDiffuse}
 ${ModestyB}
 ${TillTexcord}\n
 mov ${texcoord}.xyzw, ${TexcoordX}\n
-${TillGlow}\n
-sqrt ${storage}.xyxx, ${Glow}\n
+; ${TillGlow}\n
+; sqrt ${storage}.xyxx, ${Glow}\n
 ;${Tillo2CBPick}\n
-${Tillo2Pick}\n
-movc ${storage}.z, ${o2Pick}\n
+; ${Tillo2Pick}\n
+; movc ${storage}.z, ${o2Pick}\n
 ${Tillo1}\n
-mov ${o1}.xyz, ${o1var}\n
+mov ${o1}.${o1var}\n
+mov ${storage}.xyxx, ${o1}.wwww\n
 ${Tillo2}\n
 mov ${o2}.${o2var}\n
-mov ${o2}.z, ${storage}.z\n
+; mov ${o2}.z, ${storage}.z\n
 ${TillBloom}\n
 mov ${storage}.w, ${Bloom}\n
 ${TillRet}
@@ -88,7 +89,7 @@ if_z ${ini}.y\n
 ; \t\t    ld_indexable(texture2d)(float,float,float,float) ${tex69}.xyzw, ${dim}.xyzy, t69.xyzw\n
 \t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 \t\t    mul ${tex69}.yz, ${tex69}.yz, ${ini}.yz\n
-\t\t    add ${tex69}.yz, ${tex69}.yz, ${storage}.wx\n
+\t\t    add_sat ${tex69}.yz, ${tex69}.yz, ${storage}.wx\n
 ; Alpha Channel
 ;\t\t    max ${tex69}.xyzw, ${tex69}.xyzw, ${ini}.xxxx\n
 \t\t    if_nz ${tex69}.w\n
@@ -197,5 +198,5 @@ if_z ${ini}.y\n
 \t  endif\n
 endif\n
 ; debugging, remove diffuse
-; discard_z l(0)\n
+;discard_z l(0)\n
 ret

--- a/hic_sunt_dracones/Diffuse2SidedRegex.ini
+++ b/hic_sunt_dracones/Diffuse2SidedRegex.ini
@@ -88,7 +88,7 @@ if_z ${ini}.y\n
 ; \t\t    ld_indexable(texture2d)(float,float,float,float) ${tex69}.xyzw, ${dim}.xyzy, t69.xyzw\n
 \t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 \t\t    mul ${tex69}.yz, ${tex69}.yz, ${ini}.yz\n
-\t\t    add_sat ${tex69}.yz, ${tex69}.yx, ${storage}.wx\n
+\t\t    add ${tex69}.yz, ${tex69}.yz, ${storage}.wx\n
 ; Alpha Channel
 ;\t\t    max ${tex69}.xyzw, ${tex69}.xyzw, ${ini}.xxxx\n
 \t\t    if_nz ${tex69}.w\n
@@ -183,16 +183,17 @@ if_z ${ini}.y\n
 
 \t\t\t      endif\n
 \t\t    endif\n
+\t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) r0.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 ; Green Channel
-\t\t    if_nz ${tex69}.y\n
+\t\t    if_nz r0.y\n
 \t\t\t		mov o1.w, ${tex69}.y\n
 \t\t	endif\n
 ; Blue Channel
-\t\t	if_nz ${tex69}.z\n
+\t\t	if_nz r0.z\n
 \t\t\t		mov o4.x, ${tex69}.z\n
 \t\t	endif\n
 ; Red Channel
-\t\t	discard_nz ${tex69}.x\n
+\t\t	discard_nz r0.x\n
 \t  endif\n
 endif\n
 ; debugging, remove diffuse

--- a/hic_sunt_dracones/Diffuse2SidedRegex53.ini
+++ b/hic_sunt_dracones/Diffuse2SidedRegex53.ini
@@ -89,7 +89,7 @@ if_z ${ini}.y\n
 ; \t\t    ld_indexable(texture2d)(float,float,float,float) ${tex69}.xyzw, ${dim}.xyzy, t69.xyzw\n
 \t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 \t\t    mul ${tex69}.yz, ${tex69}.yz, ${ini}.yz\n
-\t\t    add_sat ${tex69}.yz, ${tex69}.yx, ${storage}.wx\n
+\t\t    add_sat ${tex69}.yz, ${tex69}.yz, ${storage}.wx\n
 ; Alpha Channel
 ;\t\t    max ${tex69}.xyzw, ${tex69}.xyzw, ${ini}.xxxx\n
 \t\t    if_nz ${tex69}.w\n
@@ -184,16 +184,17 @@ if_z ${ini}.y\n
 
 \t\t\t      endif\n
 \t\t    endif\n
+\t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) r0.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 ; Green Channel
-\t\t    if_nz ${tex69}.y\n
+\t\t    if_nz r0.y\n
 \t\t\t		mov o1.w, ${tex69}.y\n
 \t\t	endif\n
 ; Blue Channel
-\t\t	if_nz ${tex69}.z\n
+\t\t	if_nz r0.z\n
 \t\t\t		mov o4.x, ${tex69}.z\n
 \t\t	endif\n
 ; Red Channel
-\t\t	discard_nz ${tex69}.x\n
+\t\t	discard_nz r0.x\n
 \t  endif\n
 endif\n
 ; debugging, remove diffuse

--- a/hic_sunt_dracones/Diffuse2SidedRegex53.ini
+++ b/hic_sunt_dracones/Diffuse2SidedRegex53.ini
@@ -1,8 +1,8 @@
 namespace = TexFx
 
-[ShaderRegexDiffuseTransparency]
+[ShaderRegexDiffuse2Sided53]
 shader_model = ps_4_0 ps_5_0
-filter_index = 4243.05
+filter_index = 4243.07
 temps = ini tex69 dim storage color o1 o2 texcoord
 if ps-t69 === 0
     run = CommandListClearInstanceValues
@@ -14,8 +14,9 @@ endif
 
 
 ;Cute regex to match (almost) every character diffuse shader and outline
-[ShaderRegexDiffuseTransparency.Pattern]
+[ShaderRegexDiffuse2Sided53.Pattern]
 (?s)(?<MatchDiffuse>
+dcl_input_ps_sgv constant v\d{1,2}\.x, is_front_face\n
 dcl_output o0\.xyzw\n
 dcl_output o1\.xyzw\n
 dcl_output o2\.xyzw\n
@@ -40,37 +41,38 @@ dcl_output o5\.x\n
 ^\s+mad -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, l\(-?\d*\.?\d+\), -?r\d+\.\w+\n
 ^\s+add -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n
 ^\s+lt -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n.*)
-(?P<TillTexcord>sample_[b_]{0,2}indexable\(texture2d\)\(float,float,float,float\) r\d\d?\.[xyzw]+, (?P<TexcoordX>v(2|1[01])\.xyxx), t[01].[xyzw]+, s\d(, \w\d+(\.[xyzw]+)?)?$)
-(?P<TillGlow>.*sqrt o1\.w, (?<Glow>r\d+\.[xyzw]+))
-;(?<Tillo2CBPick>.*cb0\[(?<cb0o2pick>\d+)\].[xyzw]+, l\(0.00392156886\))
-(?<Tillo2Pick>.*movc o2\.z, (?<o2Pick>r\d\.[xyzw]+, r\d\.[xyzw]+, r\d\.[xyzw]+))
-(?P<Tillo1>.*mov o1\.xyz, (?<o1var>r\d+\.[xyzw]+))
-(?P<Tillo2>.*mov o2\.(?<o2var>[xyw]+, r\d\.[xyzw]+))
+(?P<TillTexcord>sample_[b_]{0,2}indexable\(texture2d\)\(float,float,float,float\) r\d\d?\.[xyzw]+, (?P<TexcoordX>r\d\d?.(xyxx|yzyy)), t[01].[xyzw]+, s\d(, \w\d+(\.[xyzw]+)?)?$)
+; (?P<TillGlow>.*sqrt o1\.w, (?<Glow>r\d+\.[xyzw]+))
+; ;(?<Tillo2CBPick>.*cb0\[(?<cb0o2pick>\d+)\].[xyzw]+, l\(0.00392156886\))
+; (?<Tillo2Pick>.*movc o2\.z, (?<o2Pick>r\d\.[xyzw]+, r\d\.[xyzw]+, r\d\.[xyzw]+))
+(?P<Tillo1>.*mov o1\.(?<o1var>[xyzw]{4}, r\d\.[xyzw]+))
+(?P<Tillo2>.*mov o2\.(?<o2var>[xyzw]+, r\d\.[xyzw]+))
 (?P<TillBloom>.*mov o4.x, (?<Bloom>r\d+\.[xyzw]+))
 (?P<TillRet>.*)
 ret
 
-[ShaderRegexDiffuseTransparency.InsertDeclarations]
+[ShaderRegexDiffuse2Sided53.InsertDeclarations]
 dcl_resource_texture1d (float,float,float,float) t120
 dcl_resource_texture2d (float,float,float,float) t69
 dcl_sampler s15, mode_default
 
 ;Inserts a discard statement if any pixel from our ps-t69 texture is not OPAQUE
-[ShaderRegexDiffuseTransparency.Pattern.Replace]
+[ShaderRegexDiffuse2Sided53.Pattern.Replace]
 ${MatchDiffuse}
 ${ModestyB}
 ${TillTexcord}\n
 mov ${texcoord}.xyzw, ${TexcoordX}\n
-${TillGlow}\n
-sqrt ${storage}.xyxx, ${Glow}\n
+; ${TillGlow}\n
+; sqrt ${storage}.xyxx, ${Glow}\n
 ;${Tillo2CBPick}\n
-${Tillo2Pick}\n
-movc ${storage}.z, ${o2Pick}\n
+; ${Tillo2Pick}\n
+; movc ${storage}.z, ${o2Pick}\n
 ${Tillo1}\n
-mov ${o1}.xyz, ${o1var}\n
+mov ${o1}.${o1var}\n
+mov ${storage}.xyxx, ${o1}.wwww\n
 ${Tillo2}\n
 mov ${o2}.${o2var}\n
-mov ${o2}.z, ${storage}.z\n
+; mov ${o2}.z, ${storage}.z\n
 ${TillBloom}\n
 mov ${storage}.w, ${Bloom}\n
 ${TillRet}
@@ -195,5 +197,5 @@ if_z ${ini}.y\n
 \t  endif\n
 endif\n
 ; debugging, remove diffuse
-; discard_z l(0)\n
+;discard_z l(0)\n
 ret

--- a/hic_sunt_dracones/Diffuse2SidedRegex53.ini
+++ b/hic_sunt_dracones/Diffuse2SidedRegex53.ini
@@ -42,11 +42,11 @@ dcl_output o5\.x\n
 ^\s+add -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n
 ^\s+lt -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n.*)
 (?P<TillTexcord>sample_[b_]{0,2}indexable\(texture2d\)\(float,float,float,float\) r\d\d?\.[xyzw]+, (?P<TexcoordX>r\d\d?.(xyxx|yzyy)), t[01].[xyzw]+, s\d(, \w\d+(\.[xyzw]+)?)?$)
-; (?P<TillGlow>.*sqrt o1\.w, (?<Glow>r\d+\.[xyzw]+))
-; ;(?<Tillo2CBPick>.*cb0\[(?<cb0o2pick>\d+)\].[xyzw]+, l\(0.00392156886\))
-; (?<Tillo2Pick>.*movc o2\.z, (?<o2Pick>r\d\.[xyzw]+, r\d\.[xyzw]+, r\d\.[xyzw]+))
-(?P<Tillo1>.*mov o1\.(?<o1var>[xyzw]{4}, r\d\.[xyzw]+))
-(?P<Tillo2>.*mov o2\.(?<o2var>[xyzw]+, r\d\.[xyzw]+))
+(?P<TillGlow>.*sqrt o1\.w, (?<Glow>r\d+\.[xyzw]+))
+;(?<Tillo2CBPick>.*cb0\[(?<cb0o2pick>\d+)\].[xyzw]+, l\(0.00392156886\))
+(?<Tillo2Pick>.*movc o2\.z, (?<o2Pick>r\d\.[xyzw]+, r\d\.[xyzw]+, r\d\.[xyzw]+))
+(?P<Tillo1>.*mov o1\.xyz, (?<o1var>r\d+\.[xyzw]+))
+(?P<Tillo2>.*mov o2\.(?<o2var>[xyw]+, r\d\.[xyzw]+))
 (?P<TillBloom>.*mov o4.x, (?<Bloom>r\d+\.[xyzw]+))
 (?P<TillRet>.*)
 ret
@@ -62,17 +62,16 @@ ${MatchDiffuse}
 ${ModestyB}
 ${TillTexcord}\n
 mov ${texcoord}.xyzw, ${TexcoordX}\n
-; ${TillGlow}\n
-; sqrt ${storage}.xyxx, ${Glow}\n
+${TillGlow}\n
+sqrt ${storage}.xyxx, ${Glow}\n
 ;${Tillo2CBPick}\n
-; ${Tillo2Pick}\n
-; movc ${storage}.z, ${o2Pick}\n
+${Tillo2Pick}\n
+movc ${storage}.z, ${o2Pick}\n
 ${Tillo1}\n
-mov ${o1}.${o1var}\n
-mov ${storage}.xyxx, ${o1}.wwww\n
+mov ${o1}.xyz, ${o1var}\n
 ${Tillo2}\n
 mov ${o2}.${o2var}\n
-; mov ${o2}.z, ${storage}.z\n
+mov ${o2}.z, ${storage}.z\n
 ${TillBloom}\n
 mov ${storage}.w, ${Bloom}\n
 ${TillRet}
@@ -89,7 +88,7 @@ if_z ${ini}.y\n
 ; \t\t    ld_indexable(texture2d)(float,float,float,float) ${tex69}.xyzw, ${dim}.xyzy, t69.xyzw\n
 \t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 \t\t    mul ${tex69}.yz, ${tex69}.yz, ${ini}.yz\n
-\t\t    add_sat ${tex69}.yz, ${tex69}.yz, ${storage}.wx\n
+\t\t    add ${tex69}.yz, ${tex69}.yz, ${storage}.wx\n
 ; Alpha Channel
 ;\t\t    max ${tex69}.xyzw, ${tex69}.xyzw, ${ini}.xxxx\n
 \t\t    if_nz ${tex69}.w\n
@@ -198,5 +197,5 @@ if_z ${ini}.y\n
 \t  endif\n
 endif\n
 ; debugging, remove diffuse
-;discard_z l(0)\n
+; discard_z l(0)\n
 ret

--- a/hic_sunt_dracones/DiffusePixelShaderRegex.ini
+++ b/hic_sunt_dracones/DiffusePixelShaderRegex.ini
@@ -87,7 +87,7 @@ if_z ${ini}.y\n
 ; \t\t    ld_indexable(texture2d)(float,float,float,float) ${tex69}.xyzw, ${dim}.xyzy, t69.xyzw\n
 \t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 \t\t    mul ${tex69}.yz, ${tex69}.yz, ${ini}.yz\n
-\t\t    add_sat ${tex69}.yz, ${tex69}.yx, ${storage}.wx\n
+\t\t    add_sat ${tex69}.yz, ${tex69}.yz, ${storage}.wx\n
 ; Alpha Channel
 ;\t\t    max ${tex69}.xyzw, ${tex69}.xyzw, ${ini}.xxxx\n
 \t\t    if_nz ${tex69}.w\n
@@ -182,16 +182,17 @@ if_z ${ini}.y\n
 
 \t\t\t      endif\n
 \t\t    endif\n
+\t\t    sample_aoffimmi_indexable(0,0,0)(texture2d)(float,float,float,float) r0.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 ; Green Channel
-\t\t    if_nz ${tex69}.y\n
+\t\t    if_nz r0.y\n
 \t\t\t		mov o1.w, ${tex69}.y\n
 \t\t	endif\n
 ; Blue Channel
-\t\t	if_nz ${tex69}.z\n
+\t\t	if_nz r0.z\n
 \t\t\t		mov o4.x, ${tex69}.z\n
 \t\t	endif\n
 ; Red Channel
-\t\t	discard_nz ${tex69}.x\n
+\t\t	discard_nz r0.x\n
 \t  endif\n
 endif\n
 ; debugging, remove diffuse

--- a/hic_sunt_dracones/DiffusePixelShaderRegex.ini
+++ b/hic_sunt_dracones/DiffusePixelShaderRegex.ini
@@ -41,11 +41,11 @@ dcl_output o5\.x\n
 ^\s+add -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n
 ^\s+lt -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n.*)
 (?P<TillTexcord>sample_[b_]{0,2}indexable\(texture2d\)\(float,float,float,float\) r\d\d?\.[xyzw]+, (?P<TexcoordX>v(2|1[01])\.xyxx), t[01].[xyzw]+, s\d(, \w\d+(\.[xyzw]+)?)?$)
-(?P<TillGlow>.*sqrt o1\.w, (?<Glow>r\d+\.[xyzw]+))
-;(?<Tillo2CBPick>.*cb0\[(?<cb0o2pick>\d+)\].[xyzw]+, l\(0.00392156886\))
-(?<Tillo2Pick>.*movc o2\.z, (?<o2Pick>r\d\.[xyzw]+, r\d\.[xyzw]+, r\d\.[xyzw]+))
-(?P<Tillo1>.*mov o1\.xyz, (?<o1var>r\d+\.[xyzw]+))
-(?P<Tillo2>.*mov o2\.(?<o2var>[xyw]+, r\d\.[xyzw]+))
+; (?P<TillGlow>.*sqrt o1\.w, (?<Glow>r\d+\.[xyzw]+))
+; ;(?<Tillo2CBPick>.*cb0\[(?<cb0o2pick>\d+)\].[xyzw]+, l\(0.00392156886\))
+; (?<Tillo2Pick>.*movc o2\.z, (?<o2Pick>r\d\.[xyzw]+, r\d\.[xyzw]+, r\d\.[xyzw]+))
+(?P<Tillo1>.*mov o1\.(?<o1var>[xyzw]{4}, r\d\.[xyzw]+))
+(?P<Tillo2>.*mov o2\.(?<o2var>[xyzw]+, r\d\.[xyzw]+))
 (?P<TillBloom>.*mov o4.x, (?<Bloom>r\d+\.[xyzw]+))
 (?P<TillRet>.*)
 ret
@@ -61,16 +61,17 @@ ${MatchDiffuse}
 ${ModestyB}
 ${TillTexcord}\n
 mov ${texcoord}.xyzw, ${TexcoordX}\n
-${TillGlow}\n
-sqrt ${storage}.xyxx, ${Glow}\n
+; ${TillGlow}\n
+; sqrt ${storage}.xyxx, ${Glow}\n
 ;${Tillo2CBPick}\n
-${Tillo2Pick}\n
-movc ${storage}.z, ${o2Pick}\n
+; ${Tillo2Pick}\n
+; movc ${storage}.z, ${o2Pick}\n
 ${Tillo1}\n
-mov ${o1}.xyz, ${o1var}\n
+mov ${o1}.${o1var}\n
+mov ${storage}.xyxx, ${o1}.wwww\n
 ${Tillo2}\n
 mov ${o2}.${o2var}\n
-mov ${o2}.z, ${storage}.z\n
+; mov ${o2}.z, ${storage}.z\n
 ${TillBloom}\n
 mov ${storage}.w, ${Bloom}\n
 ${TillRet}
@@ -87,7 +88,7 @@ if_z ${ini}.y\n
 ; \t\t    ld_indexable(texture2d)(float,float,float,float) ${tex69}.xyzw, ${dim}.xyzy, t69.xyzw\n
 \t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 \t\t    mul ${tex69}.yz, ${tex69}.yz, ${ini}.yz\n
-\t\t    add_sat ${tex69}.yz, ${tex69}.yz, ${storage}.wx\n
+\t\t    add ${tex69}.yz, ${tex69}.yz, ${storage}.wx\n
 ; Alpha Channel
 ;\t\t    max ${tex69}.xyzw, ${tex69}.xyzw, ${ini}.xxxx\n
 \t\t    if_nz ${tex69}.w\n
@@ -182,7 +183,7 @@ if_z ${ini}.y\n
 
 \t\t\t      endif\n
 \t\t    endif\n
-\t\t    sample_aoffimmi_indexable(0,0,0)(texture2d)(float,float,float,float) r0.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
+\t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) r0.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 ; Green Channel
 \t\t    if_nz r0.y\n
 \t\t\t		mov o1.w, ${tex69}.y\n

--- a/hic_sunt_dracones/DiffusePixelShaderRegex53.ini
+++ b/hic_sunt_dracones/DiffusePixelShaderRegex53.ini
@@ -41,11 +41,11 @@ dcl_output o5\.x\n
 ^\s+add -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n
 ^\s+lt -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n.*)
 (?P<TillTexcord>sample_[b_]{0,2}indexable\(texture2d\)\(float,float,float,float\) r\d\d?\.[xyzw]+, (?P<TexcoordX>v(2|1[01])\.xyxx), t[01].[xyzw]+, s\d(, \w\d+(\.[xyzw]+)?)?$)
-; (?P<TillGlow>.*sqrt o1\.w, (?<Glow>r\d+\.[xyzw]+))
-; ;(?<Tillo2CBPick>.*cb0\[(?<cb0o2pick>\d+)\].[xyzw]+, l\(0.00392156886\))
-; (?<Tillo2Pick>.*movc o2\.z, (?<o2Pick>r\d\.[xyzw]+, r\d\.[xyzw]+, r\d\.[xyzw]+))
-(?P<Tillo1>.*mov o1\.(?<o1var>[xyzw]{4}, r\d\.[xyzw]+))
-(?P<Tillo2>.*mov o2\.(?<o2var>[xyzw]+, r\d\.[xyzw]+))
+(?P<TillGlow>.*sqrt o1\.w, (?<Glow>r\d+\.[xyzw]+))
+;(?<Tillo2CBPick>.*cb0\[(?<cb0o2pick>\d+)\].[xyzw]+, l\(0.00392156886\))
+(?<Tillo2Pick>.*movc o2\.z, (?<o2Pick>r\d\.[xyzw]+, r\d\.[xyzw]+, r\d\.[xyzw]+))
+(?P<Tillo1>.*mov o1\.xyz, (?<o1var>r\d+\.[xyzw]+))
+(?P<Tillo2>.*mov o2\.(?<o2var>[xyw]+, r\d\.[xyzw]+))
 (?P<TillBloom>.*mov o4.x, (?<Bloom>r\d+\.[xyzw]+))
 (?P<TillRet>.*)
 ret
@@ -61,17 +61,16 @@ ${MatchDiffuse}
 ${ModestyB}
 ${TillTexcord}\n
 mov ${texcoord}.xyzw, ${TexcoordX}\n
-; ${TillGlow}\n
-; sqrt ${storage}.xyxx, ${Glow}\n
+${TillGlow}\n
+sqrt ${storage}.xyxx, ${Glow}\n
 ;${Tillo2CBPick}\n
-; ${Tillo2Pick}\n
-; movc ${storage}.z, ${o2Pick}\n
+${Tillo2Pick}\n
+movc ${storage}.z, ${o2Pick}\n
 ${Tillo1}\n
-mov ${o1}.${o1var}\n
-mov ${storage}.xyxx, ${o1}.wwww\n
+mov ${o1}.xyz, ${o1var}\n
 ${Tillo2}\n
 mov ${o2}.${o2var}\n
-; mov ${o2}.z, ${storage}.z\n
+mov ${o2}.z, ${storage}.z\n
 ${TillBloom}\n
 mov ${storage}.w, ${Bloom}\n
 ${TillRet}
@@ -88,7 +87,7 @@ if_z ${ini}.y\n
 ; \t\t    ld_indexable(texture2d)(float,float,float,float) ${tex69}.xyzw, ${dim}.xyzy, t69.xyzw\n
 \t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 \t\t    mul ${tex69}.yz, ${tex69}.yz, ${ini}.yz\n
-\t\t    add ${tex69}.yz, ${tex69}.yz, ${storage}.wx\n
+\t\t    add_sat ${tex69}.yz, ${tex69}.yz, ${storage}.wx\n
 ; Alpha Channel
 ;\t\t    max ${tex69}.xyzw, ${tex69}.xyzw, ${ini}.xxxx\n
 \t\t    if_nz ${tex69}.w\n
@@ -183,7 +182,7 @@ if_z ${ini}.y\n
 
 \t\t\t      endif\n
 \t\t    endif\n
-\t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) r0.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
+\t\t    sample_aoffimmi_indexable(0,0,0)(texture2d)(float,float,float,float) r0.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 ; Green Channel
 \t\t    if_nz r0.y\n
 \t\t\t		mov o1.w, ${tex69}.y\n

--- a/hic_sunt_dracones/DiffusePixelShaderRegex53.ini
+++ b/hic_sunt_dracones/DiffusePixelShaderRegex53.ini
@@ -88,7 +88,7 @@ if_z ${ini}.y\n
 ; \t\t    ld_indexable(texture2d)(float,float,float,float) ${tex69}.xyzw, ${dim}.xyzy, t69.xyzw\n
 \t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 \t\t    mul ${tex69}.yz, ${tex69}.yz, ${ini}.yz\n
-\t\t    add ${tex69}.yz, ${tex69}.yx, ${storage}.wx\n
+\t\t    add ${tex69}.yz, ${tex69}.yz, ${storage}.wx\n
 ; Alpha Channel
 ;\t\t    max ${tex69}.xyzw, ${tex69}.xyzw, ${ini}.xxxx\n
 \t\t    if_nz ${tex69}.w\n
@@ -183,16 +183,17 @@ if_z ${ini}.y\n
 
 \t\t\t      endif\n
 \t\t    endif\n
+\t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) r0.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 ; Green Channel
-\t\t    if_nz ${tex69}.y\n
+\t\t    if_nz r0.y\n
 \t\t\t		mov o1.w, ${tex69}.y\n
 \t\t	endif\n
 ; Blue Channel
-\t\t	if_nz ${tex69}.z\n
+\t\t	if_nz r0.z\n
 \t\t\t		mov o4.x, ${tex69}.z\n
 \t\t	endif\n
 ; Red Channel
-\t\t	discard_nz ${tex69}.x\n
+\t\t	discard_nz r0.x\n
 \t  endif\n
 endif\n
 ; debugging, remove diffuse

--- a/hic_sunt_dracones/DiffusePixelShaderRegex53.ini
+++ b/hic_sunt_dracones/DiffusePixelShaderRegex53.ini
@@ -1,6 +1,6 @@
 namespace = TexFx
 
-[ShaderRegexDiffuseTransparency]
+[ShaderRegexDiffuseTransparency53]
 shader_model = ps_4_0 ps_5_0
 filter_index = 4243.05
 temps = ini tex69 dim storage color o1 o2 texcoord
@@ -14,7 +14,7 @@ endif
 
 
 ;Cute regex to match (almost) every character diffuse shader and outline
-[ShaderRegexDiffuseTransparency.Pattern]
+[ShaderRegexDiffuseTransparency53.Pattern]
 (?s)(?<MatchDiffuse>
 dcl_output o0\.xyzw\n
 dcl_output o1\.xyzw\n
@@ -41,36 +41,37 @@ dcl_output o5\.x\n
 ^\s+add -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n
 ^\s+lt -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n.*)
 (?P<TillTexcord>sample_[b_]{0,2}indexable\(texture2d\)\(float,float,float,float\) r\d\d?\.[xyzw]+, (?P<TexcoordX>v(2|1[01])\.xyxx), t[01].[xyzw]+, s\d(, \w\d+(\.[xyzw]+)?)?$)
-(?P<TillGlow>.*sqrt o1\.w, (?<Glow>r\d+\.[xyzw]+))
-;(?<Tillo2CBPick>.*cb0\[(?<cb0o2pick>\d+)\].[xyzw]+, l\(0.00392156886\))
-(?<Tillo2Pick>.*movc o2\.z, (?<o2Pick>r\d\.[xyzw]+, r\d\.[xyzw]+, r\d\.[xyzw]+))
-(?P<Tillo1>.*mov o1\.xyz, (?<o1var>r\d+\.[xyzw]+))
-(?P<Tillo2>.*mov o2\.(?<o2var>[xyw]+, r\d\.[xyzw]+))
+; (?P<TillGlow>.*sqrt o1\.w, (?<Glow>r\d+\.[xyzw]+))
+; ;(?<Tillo2CBPick>.*cb0\[(?<cb0o2pick>\d+)\].[xyzw]+, l\(0.00392156886\))
+; (?<Tillo2Pick>.*movc o2\.z, (?<o2Pick>r\d\.[xyzw]+, r\d\.[xyzw]+, r\d\.[xyzw]+))
+(?P<Tillo1>.*mov o1\.(?<o1var>[xyzw]{4}, r\d\.[xyzw]+))
+(?P<Tillo2>.*mov o2\.(?<o2var>[xyzw]+, r\d\.[xyzw]+))
 (?P<TillBloom>.*mov o4.x, (?<Bloom>r\d+\.[xyzw]+))
 (?P<TillRet>.*)
 ret
 
-[ShaderRegexDiffuseTransparency.InsertDeclarations]
+[ShaderRegexDiffuseTransparency53.InsertDeclarations]
 dcl_resource_texture1d (float,float,float,float) t120
 dcl_resource_texture2d (float,float,float,float) t69
 dcl_sampler s15, mode_default
 
 ;Inserts a discard statement if any pixel from our ps-t69 texture is not OPAQUE
-[ShaderRegexDiffuseTransparency.Pattern.Replace]
+[ShaderRegexDiffuseTransparency53.Pattern.Replace]
 ${MatchDiffuse}
 ${ModestyB}
 ${TillTexcord}\n
 mov ${texcoord}.xyzw, ${TexcoordX}\n
-${TillGlow}\n
-sqrt ${storage}.xyxx, ${Glow}\n
+; ${TillGlow}\n
+; sqrt ${storage}.xyxx, ${Glow}\n
 ;${Tillo2CBPick}\n
-${Tillo2Pick}\n
-movc ${storage}.z, ${o2Pick}\n
+; ${Tillo2Pick}\n
+; movc ${storage}.z, ${o2Pick}\n
 ${Tillo1}\n
-mov ${o1}.xyz, ${o1var}\n
+mov ${o1}.${o1var}\n
+mov ${storage}.xyxx, ${o1}.wwww\n
 ${Tillo2}\n
 mov ${o2}.${o2var}\n
-mov ${o2}.z, ${storage}.z\n
+; mov ${o2}.z, ${storage}.z\n
 ${TillBloom}\n
 mov ${storage}.w, ${Bloom}\n
 ${TillRet}
@@ -87,7 +88,7 @@ if_z ${ini}.y\n
 ; \t\t    ld_indexable(texture2d)(float,float,float,float) ${tex69}.xyzw, ${dim}.xyzy, t69.xyzw\n
 \t\t    sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 \t\t    mul ${tex69}.yz, ${tex69}.yz, ${ini}.yz\n
-\t\t    add_sat ${tex69}.yz, ${tex69}.yx, ${storage}.wx\n
+\t\t    add ${tex69}.yz, ${tex69}.yx, ${storage}.wx\n
 ; Alpha Channel
 ;\t\t    max ${tex69}.xyzw, ${tex69}.xyzw, ${ini}.xxxx\n
 \t\t    if_nz ${tex69}.w\n

--- a/hic_sunt_dracones/OutlineHull.hlsl
+++ b/hic_sunt_dracones/OutlineHull.hlsl
@@ -1,12 +1,12 @@
-//  outline offset 4.6 LeoTorreZ   ---- Created with 3Dmigoto v1.3.16 on Tue Apr 23 23:44:55 2024
+// ---- Created with 3Dmigoto v1.3.16 on Fri Feb 14 09:05:46 2025
 cbuffer cb4 : register(b4)
 {
-  float4 cb4[13];
+  float4 cb4[25];
 }
 
 cbuffer cb3 : register(b3)
 {
-  float4 cb3[8];
+  float4 cb3[7];
 }
 
 cbuffer cb2 : register(b2)
@@ -21,7 +21,7 @@ cbuffer cb1 : register(b1)
 
 cbuffer cb0 : register(b0)
 {
-  float4 cb0[57];
+  float4 cb0[149];
 }
 
 
@@ -30,366 +30,190 @@ cbuffer cb0 : register(b0)
 // 3Dmigoto declarations
 #define cmp -
 Texture1D<float4> IniParams : register(t120);
-Texture2D<float4> StereoParams : register(t125);
 #define OFFSET IniParams[169].x
-
 
 void main(
   float4 v0 : POSITION0,
   float4 v1 : COLOR0,
-  float3 v2 : NORMAL0,
-  float4 v3 : TANGENT0,
-  float4 v4 : TEXCOORD0,
-  float2 v5 : TEXCOORD1,
+  float4 v2 : TEXCOORD0,
+  float4 v3 : TEXCOORD1,
+  float4 v4 : TEXCOORD2,
+  float4 v5 : TEXCOORD3,
+  float3 v6 : NORMAL0,
+  float4 v7 : TANGENT0,
   out float4 o0 : SV_POSITION0,
   out float4 o1 : COLOR0,
   out float4 o2 : TEXCOORD0,
   out float4 o3 : TEXCOORD1,
-  out float4 o4 : TEXCOORD2)
+  out float4 o4 : TEXCOORD3,
+  out float4 o5 : TEXCOORD4,
+  out float4 o6 : TEXCOORD5,
+  out float4 o7 : TEXCOORD6,
+  out float4 o8 : TEXCOORD7,
+  out float4 o9 : TEXCOORD8)
 {
-  float4 r0,r1,r2,r3,r4,r5;
+  float4 r0,r1,r2,r3,r4,r5,r6;
   uint4 bitmask, uiDest;
   float4 fDest;
-  v1.zw = float2(0.0,0.0);
-  r5.xyzw = float4(0.0,0.0,0.0,0.0);
-  o0 = r5;
-  o1 = r5;
-  o2 = r5;
-  o3 = r5;
-  o4 = r5;
 
-  r0.x = cmp(cb0[24].x == 0.000000);
-  if (r0.x != 0) {
-    o0.xyzw = float4(0,0,0,0);
-    o1.xyzw = float4(0,0,0,0);
-    o4.xyzw = float4(0,0,0,0);
-    o3.xyz = float3(0,0,0);
-    o2.xy = float2(0,0);
+  o0.xyzw = float4(0,0,0,0);
+  o1.xyzw = float4(0,0,0,0);
+  o2.xyzw = float4(0,0,0,0);
+  o3.xyzw = float4(0,0,0,0);
+  o4.xyzw = float4(0,0,0,0);
+  o5.xyzw = float4(0,0,0,0);
+  o6.xyzw = float4(0,0,0,0);
+  o7.xyzw = float4(0,0,0,0);
+  o8.xyzw = float4(0,0,0,0);
+  o9.xyzw = float4(0,0,0,0);
+
+  r0.xyz = cb3[1].xyz * v0.yyy;
+  r0.xyz = cb3[0].xyz * v0.xxx + r0.xyz;
+  r0.xyz = cb3[2].xyz * v0.zzz + r0.xyz;
+  r0.xyz = cb3[3].xyz + r0.xyz;
+  r1.xyz = cb1[5].xyz + -r0.xyz;
+  r0.w = dot(r1.xyz, r1.xyz);
+  r0.w = rsqrt(r0.w);
+  o4.xyz = r1.xyz * r0.www;
+  r2.x = dot(v6.xyz, cb3[4].xyz);
+  r2.y = dot(v6.xyz, cb3[5].xyz);
+  r2.z = dot(v6.xyz, cb3[6].xyz);
+  r0.w = dot(r2.xyz, r2.xyz);
+  r0.w = rsqrt(r0.w);
+  r2.xyz = r2.xyz * r0.www;
+  r3.xyzw = cb3[1].xyzw * v0.yyyy;
+  r3.xyzw = cb3[0].xyzw * v0.xxxx + r3.xyzw;
+  r3.xyzw = cb3[2].xyzw * v0.zzzz + r3.xyzw;
+  r3.xyzw = cb3[3].xyzw + r3.xyzw;
+  r0.w = cb4[10].z * r3.y;
+  r0.w = cb4[9].z * r3.x + r0.w;
+  r0.w = cb4[11].z * r3.z + r0.w;
+  r0.w = cb4[12].z * r3.w + r0.w;
+  o4.w = -r0.w;
+  r3.xyw = cb3[3].xyz + -cb1[5].xyz;
+  r4.x = cb3[0].x;
+  r4.y = cb3[1].x;
+  r4.z = cb3[2].x;
+  r4.w = r3.x;
+  r5.xyz = v0.xyz;
+  r5.w = 1;
+  r4.x = dot(r4.xyzw, r5.xyzw);
+  r6.x = cb3[0].y;
+  r6.y = cb3[1].y;
+  r6.z = cb3[2].y;
+  r6.w = r3.y;
+  r4.y = dot(r6.xyzw, r5.xyzw);
+  r3.x = cb3[0].z;
+  r3.y = cb3[1].z;
+  r3.z = cb3[2].z;
+  r4.z = dot(r3.xyzw, r5.xyzw);
+  r3.x = cb3[0].w;
+  r3.y = cb3[1].w;
+  r3.z = cb3[2].w;
+  r3.w = cb3[3].w;
+  r4.w = dot(r3.xyzw, r5.xyzw);
+  r4.y += OFFSET;
+  r3.x = cb4[9].x;
+  r3.y = cb4[10].x;
+  r3.z = cb4[11].x;
+  r3.x = dot(r3.xyz, r4.xyz);
+  r5.x = cb4[9].y;
+  r5.y = cb4[10].y;
+  r5.z = cb4[11].y;
+  r3.y = dot(r5.xyz, r4.xyz);
+  r5.x = cb4[9].z;
+  r5.y = cb4[10].z;
+  r5.z = cb4[11].z;
+  r3.z = dot(r5.xyz, r4.xyz);
+  r5.x = cb4[9].w;
+  r5.y = cb4[10].w;
+  r5.z = cb4[11].w;
+  r5.w = cb4[12].w;
+  r0.w = dot(r5.xyzw, r4.xyzw);
+  r5.xyz = cb3[1].xyz * v7.yyy;
+  r5.xyz = cb3[0].xyz * v7.xxx + r5.xyz;
+  r5.xyz = cb3[2].xyz * v7.zzz + r5.xyz;
+  r5.yw = cb4[10].xy * r5.yy;
+  r5.xy = cb4[9].xy * r5.xx + r5.yw;
+  r5.xy = cb4[11].xy * r5.zz + r5.xy;
+  r5.z = 0.00999999978;
+  r1.w = dot(r5.xyz, r5.xyz);
+  r1.w = rsqrt(r1.w);
+  r5.xy = r5.xy * r1.ww;
+  r1.w = 2.41400003 / cb2[7].y;
+  r2.w = -r3.z * r1.w;
+  r2.w = cmp(r2.w < cb0[122].y);
+  r6.xy = r2.ww ? cb0[122].xy : cb0[122].yz;
+  r6.zw = r2.ww ? cb0[123].xy : cb0[123].yz;
+  r1.w = -r3.z * r1.w + -r6.x;
+  r5.zw = r6.yw + -r6.xz;
+  r2.w = max(0.00100000005, r5.z);
+  r1.w = saturate(r1.w / r2.w);
+  r1.w = r1.w * r5.w + r6.z;
+  r2.w = cb0[146].w * cb0[121].x;
+  r1.w = r2.w * r1.w;
+  r1.w = v1.w * r1.w;
+  r1.w = 0.414250195 * r1.w;
+  r2.w = dot(r3.xyz, r3.xyz);
+  r2.w = rsqrt(r2.w);
+  r6.xyz = r3.xyz * r2.www;
+  r6.xyz = cb0[121].yyy * r6.xyz;
+  r6.xyz = float3(0.00999999978,0.00999999978,0.00999999978) * r6.xyz;
+  r2.w = cmp(cb0[121].z < 0.5);
+  r3.w = -0.5 + v1.z;
+  r2.w = r2.w ? r3.w : 1;
+  r3.xyz = r6.xyz * r2.www + r3.xyz;
+  r3.xy = r5.xy * r1.ww + r3.xy;
+  r5.xyzw = cb4[6].xyzw * r3.yyyy;
+  r5.xyzw = cb4[5].xyzw * r3.xxxx + r5.xyzw;
+  r3.xyzw = cb4[7].xyzw * r3.zzzz + r5.xyzw;
+  r3.xyzw = cb4[8].xywz * r0.wwww + r3.xywz;
+  r0.w = dot(r1.xyz, r2.xyz);
+  r0.w = cmp(r0.w < 0);
+  r0.w = r0.w ? cb0[28].x : 0;
+  o0.z = r3.w + -r0.w;
+  r0.w = cmp(0 != cb0[133].y);
+  r1.x = cmp(cb0[133].z < 0.949999988);
+  r1.x = r0.w ? r1.x : 0;
+  r1.y = cb1[6].x * cb0[148].w;
+  r5.x = cb0[148].z * r3.z;
+  r5.y = r1.y * r3.z;
+  r1.yz = r5.xy * float2(2,2) + r3.xy;
+  r3.xy = r1.xx ? r1.yz : r3.xy;
+  r1.yz = float2(0.5,0.5);
+  if (r0.w != 0) {
+    r1.xz = float2(0.5,0.5);
+    r1.y = cb1[6].x;
+    r1.xyz = r3.xyz * r1.xyz;
+    r1.w = 0.5 * r1.y;
+    o3.xy = r1.xw + r1.zz;
+    o3.z = cb0[133].z;
+    o3.w = r3.z;
+  } else {
+    r1.xyzw = cb4[22].xyzw * r4.yyyy;
+    r1.xyzw = cb4[21].xyzw * r4.xxxx + r1.xyzw;
+    r1.xyzw = cb4[23].xyzw * r4.zzzz + r1.xyzw;
+    r1.xyzw = cb4[24].xyzw * r4.wwww + r1.xyzw;
+    r4.xz = float2(0.5,0.5);
+    r4.y = cb1[6].x;
+    r4.xyz = r4.xyz * r1.xyw;
+    r4.w = 0.5 * r4.y;
+    o3.xy = r4.xw + r4.zz;
+    o3.zw = r1.zw;
   }
-  if (r0.x == 0) {
-    r0.xy = cmp(float2(0,0) != cb0[36].yz);
-    r0.z = cmp(abs(cb0[37].w) < 0.00100000005);
-    r1.xyz = cb0[37].xyz * cb0[37].www;
-    r1.xyz = r0.zzz ? float3(0,0,0) : r1.xyz;
-    r2.xyzw = cb3[5].xyzw * r1.yyyy;
-    r2.xyzw = cb3[4].xyzw * r1.xxxx + r2.xyzw;
-    r1.xyzw = cb3[6].xyzw * r1.zzzz + r2.xyzw;
-    r1.xyzw = cb3[7].xyzw + r1.xyzw;
-    r1.xyz = r1.xyz / r1.www;
-    r2.xyz = cb3[5].xyz * cb0[37].yyy;
-    r2.xyz = cb3[4].xyz * cb0[37].xxx + r2.xyz;
-    r2.xyz = cb3[6].xyz * cb0[37].zzz + r2.xyz;
-    r0.z = dot(r1.xyz, r2.xyz);
-    r0.w = dot(v0.xyz, r2.xyz);
-    r1.x = cmp(r0.w < r0.z);
-    r0.z = r0.w + -r0.z;
-    r2.xyz = -r0.zzz * r2.xyz + v0.xyz;
-    r2.w = 0;
-    r3.xyz = v0.xyz;
-    r3.w = 1;
-    r1.xyzw = r1.xxxx ? r2.xyzw : r3.xyzw;
-    r0.z = dot(v0.xyz, cb0[37].xyz);
-    r0.w = -0.00999999978 + cb0[37].w;
-    r0.w = cmp(r0.z < r0.w);
-    r0.z = -cb0[37].w + r0.z;
-    r2.xyz = -r0.zzz * cb0[37].xyz + v0.xyz;
-    r2.w = 0;
-    r2.xyzw = r0.wwww ? r2.xyzw : r3.xyzw;
-    r1.xyzw = r0.yyyy ? r1.xyzw : r2.xyzw;
-    r0.xyzw = r0.xxxx ? r1.xyzw : r3.xyzw;
-    r1.xyw = cb3[3].xyz + -cb1[5].xyz;
-    r2.x = cb3[0].x;
-    r2.y = cb3[1].x;
-    r2.z = cb3[2].x;
-    r2.w = r1.x;
-    r3.xyz = r0.xyz;
-    r3.w = v0.w;
-    r2.x = dot(r2.xyzw, r3.xyzw);
-    r4.x = cb3[0].y;
-    r4.y = cb3[1].y;
-    r4.z = cb3[2].y;
-    r4.w = r1.y;
-    r2.y = dot(r4.xyzw, r3.xyzw);
-    r1.x = cb3[0].z;
-    r1.y = cb3[1].z;
-    r1.z = cb3[2].z;
-    r2.z = dot(r1.xyzw, r3.xyzw);
-    r1.x = cb3[0].w;
-    r1.y = cb3[1].w;
-    r1.z = cb3[2].w;
-    r1.w = cb3[3].w;
-    r2.w = dot(r1.xyzw, r3.xyzw);
-    r2.y = r2.y + OFFSET;
-    r0.x = cb4[9].x;
-    r0.y = cb4[10].x;
-    r0.z = cb4[11].x;
-    r0.x = dot(r0.xyz, r2.xyz);
-    r1.x = cb4[9].y;
-    r1.y = cb4[10].y;
-    r1.z = cb4[11].y;
-    r0.y = dot(r1.xyz, r2.xyz);
-    r1.x = cb4[9].z;
-    r1.y = cb4[10].z;
-    r1.z = cb4[11].z;
-    r0.z = dot(r1.xyz, r2.xyz);
-    r1.x = cb4[9].w;
-    r1.y = cb4[10].w;
-    r1.z = cb4[11].w;
-    r1.w = cb4[12].w;
-    r1.x = dot(r1.xyzw, r2.xyzw);
-    r1.y = cmp(cb0[24].x == 1.000000);
-    r1.yzw = r1.yyy ? v2.xyz : v3.xyz;
-    r2.xyz = cb3[1].xyz * r1.zzz;
-    r2.xyz = cb3[0].xyz * r1.yyy + r2.xyz;
-    r1.yzw = cb3[2].xyz * r1.www + r2.xyz;
-    r2.xy = cb4[10].xy * r1.zz;
-    r1.yz = cb4[9].xy * r1.yy + r2.xy;
-    r2.xy = cb4[11].xy * r1.ww + r1.yz;
-    r2.z = 0.00999999978;
-    r1.y = dot(r2.xyz, r2.xyz);
-    r1.y = rsqrt(r1.y);
-    r1.yz = r2.xy * r1.yy;
-    r1.w = 2.41400003 / cb2[7].y;
-    r2.x = r1.w * -r0.z;
-    r2.x = cmp(r2.x < cb0[30].y);
-    r3.xy = r2.xx ? cb0[30].xy : cb0[30].yz;
-    r3.zw = r2.xx ? cb0[31].xy : cb0[31].yz;
-    r1.w = -r0.z * r1.w + -r3.x;
-    r2.xy = r3.yw + -r3.xz;
-    r2.x = max(0.00100000005, r2.x);
-    r1.w = saturate(r1.w / r2.x);
-    r1.w = r1.w * r2.y + r3.z;
-    r2.x = cb0[54].w * cb0[26].x;
-    r1.w = r2.x * r1.w;
-    r1.w = 100 * r1.w;
-    r1.w = cb0[28].z * r1.w;
-    r1.w = 0.414250195 * r1.w;
-    r1.w = v1.w * r1.w;
-    r2.x = dot(r0.xyz, r0.xyz);
-    r2.x = rsqrt(r2.x);
-    r2.xyz = r2.xxx * r0.xyz;
-    r2.xyz = cb0[28].xxx * r2.xyz;
-    r2.xyz = cb0[28].zzz * r2.xyz;
-    r2.w = -0.5 + v1.z;
-    r0.xyz = r2.xyz * r2.www + r0.xyz;
-    r0.xy = r1.yz * r1.ww + r0.xy;
-    r2.xyzw = cb4[6].xyzw * r0.yyyy;
-    r2.xyzw = cb4[5].xyzw * r0.xxxx + r2.xyzw;
-    r2.xyzw = cb4[7].xyzw * r0.zzzz + r2.xyzw;
-    r1.xyzw = cb4[8].xyzw * r1.xxxx + r2.xyzw;
-    r0.x = cmp(0 != cb0[41].y);
-    r0.y = cmp(cb0[41].z < 0.949999988);
-    r0.y = r0.y ? r0.x : 0;
-    r0.z = cb1[6].x * cb0[56].w;
-    r2.x = cb0[56].z * r1.w;
-    r2.y = r0.z * r1.w;
-    r2.xy = r2.xy * float2(2,2) + r1.xy;
-    r1.xy = r0.yy ? r2.xy : r1.xy;
-    r2.xz = float2(0.5,0.5);
-    r2.y = cb1[6].x;
-    r2.xyz = r2.xyz * r1.xyw;
-    r2.w = 0.5 * r2.y;
-    r2.xy = r2.xw + r2.zz;
-    r2.z = cb0[41].z;
-    r2.w = r1.w;
-    o4.xyzw = r0.xxxx ? r2.xyzw : 0;
-    o2.xy = v4.xy * cb0[40].xy + cb0[40].zw;
-    o0.xyzw = r1.xyzw;
-    o1.xyz = cb0[27].xyz;
-    o1.w = r0.w;
-    o3.xyz = float3(0,0,0);
-  }
+  o0.xyw = r3.xyz;
+  o1.xyz = cb0[118].xyz;
+  o1.w = 1;
+  o5.xyz = r2.xyz;
+  o5.w = 1;
+  o6.xy = v2.xy;
+  o6.zw = float2(0,0);
+  o7.xy = v3.xy;
+  o7.zw = float2(0,0);
+  o8.xy = v4.xy;
+  o8.zw = v5.xy;
+  o9.xyz = r0.xyz;
+  o9.w = 0;
+  o2.xyz = float3(0,0,0);
   return;
 }
-
-/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-//
-// Generated by Microsoft (R) D3D Shader Disassembler
-//
-//   using 3Dmigoto v1.3.16 on Tue Apr 23 23:44:55 2024
-//
-//
-// Input signature:
-//
-// Name                 Index   Mask Register SysValue  Format   Used
-// -------------------- ----- ------ -------- -------- ------- ------
-// POSITION                 0   xyzw        0     NONE   float   xyzw
-// COLOR                    0   xyzw        1     NONE   float     zw
-// NORMAL                   0   xyz         2     NONE   float   xyz
-// TANGENT                  0   xyzw        3     NONE   float   xyz
-// TEXCOORD                 0   xy          4     NONE   float   xy
-// TEXCOORD                 1   xy          5     NONE   float
-//
-//
-// Output signature:
-//
-// Name                 Index   Mask Register SysValue  Format   Used
-// -------------------- ----- ------ -------- -------- ------- ------
-// SV_POSITION              0   xyzw        0      POS   float   xyzw
-// COLOR                    0   xyzw        1     NONE   float   xyzw
-// TEXCOORD                 0   xy          2     NONE   float   xy
-// TEXCOORD                 1   xyz         3     NONE   float   xyz
-// TEXCOORD                 2   xyzw        4     NONE   float   xyzw
-//
-vs_5_0
-dcl_globalFlags refactoringAllowed
-dcl_constantbuffer CB0[57], immediateIndexed
-dcl_constantbuffer CB1[7], immediateIndexed
-dcl_constantbuffer CB2[8], immediateIndexed
-dcl_constantbuffer CB3[8], immediateIndexed
-dcl_constantbuffer CB4[13], immediateIndexed
-dcl_input v0.xyzw
-dcl_input v1.zw
-dcl_input v2.xyz
-dcl_input v3.xyz
-dcl_input v4.xy
-dcl_output_siv o0.xyzw, position
-dcl_output o1.xyzw
-dcl_output o2.xy
-dcl_output o3.xyz
-dcl_output o4.xyzw
-dcl_temps 5
-eq r0.x, cb0[24].x, l(0.000000)
-if_nz r0.x
-  mov o0.xyzw, l(0,0,0,0)
-  mov o1.xyzw, l(0,0,0,0)
-  mov o4.xyzw, l(0,0,0,0)
-  mov o3.xyz, l(0,0,0,0)
-  mov o2.xy, l(0,0,0,0)
-endif
-if_z r0.x
-  ne r0.xy, l(0.000000, 0.000000, 0.000000, 0.000000), cb0[36].yzyy
-  lt r0.z, |cb0[37].w|, l(0.001000)
-  mul r1.xyz, cb0[37].wwww, cb0[37].xyzx
-  movc r1.xyz, r0.zzzz, l(0,0,0,0), r1.xyzx
-  mul r2.xyzw, r1.yyyy, cb3[5].xyzw
-  mad r2.xyzw, cb3[4].xyzw, r1.xxxx, r2.xyzw
-  mad r1.xyzw, cb3[6].xyzw, r1.zzzz, r2.xyzw
-  add r1.xyzw, r1.xyzw, cb3[7].xyzw
-  div r1.xyz, r1.xyzx, r1.wwww
-  mul r2.xyz, cb0[37].yyyy, cb3[5].xyzx
-  mad r2.xyz, cb3[4].xyzx, cb0[37].xxxx, r2.xyzx
-  mad r2.xyz, cb3[6].xyzx, cb0[37].zzzz, r2.xyzx
-  dp3 r0.z, r1.xyzx, r2.xyzx
-  dp3 r0.w, v0.xyzx, r2.xyzx
-  lt r1.x, r0.w, r0.z
-  add r0.z, -r0.z, r0.w
-  mad r2.xyz, -r0.zzzz, r2.xyzx, v0.xyzx
-  mov r2.w, l(0)
-  mov r3.xyz, v0.xyzx
-  mov r3.w, l(1.000000)
-  movc r1.xyzw, r1.xxxx, r2.xyzw, r3.xyzw
-  dp3 r0.z, v0.xyzx, cb0[37].xyzx
-  add r0.w, cb0[37].w, l(-0.010000)
-  lt r0.w, r0.z, r0.w
-  add r0.z, r0.z, -cb0[37].w
-  mad r2.xyz, -r0.zzzz, cb0[37].xyzx, v0.xyzx
-  mov r2.w, l(0)
-  movc r2.xyzw, r0.wwww, r2.xyzw, r3.xyzw
-  movc r1.xyzw, r0.yyyy, r1.xyzw, r2.xyzw
-  movc r0.xyzw, r0.xxxx, r1.xyzw, r3.xyzw
-  add r1.xyw, -cb1[5].xyxz, cb3[3].xyxz
-  mov r2.x, cb3[0].x
-  mov r2.y, cb3[1].x
-  mov r2.z, cb3[2].x
-  mov r2.w, r1.x
-  mov r3.xyz, r0.xyzx
-  mov r3.w, v0.w
-  dp4 r2.x, r2.xyzw, r3.xyzw
-  mov r4.x, cb3[0].y
-  mov r4.y, cb3[1].y
-  mov r4.z, cb3[2].y
-  mov r4.w, r1.y
-  dp4 r2.y, r4.xyzw, r3.xyzw
-  mov r1.x, cb3[0].z
-  mov r1.y, cb3[1].z
-  mov r1.z, cb3[2].z
-  dp4 r2.z, r1.xyzw, r3.xyzw
-  mov r1.x, cb3[0].w
-  mov r1.y, cb3[1].w
-  mov r1.z, cb3[2].w
-  mov r1.w, cb3[3].w
-  dp4 r2.w, r1.xyzw, r3.xyzw
-  mov r0.x, cb4[9].x
-  mov r0.y, cb4[10].x
-  mov r0.z, cb4[11].x
-  dp3 r0.x, r0.xyzx, r2.xyzx
-  mov r1.x, cb4[9].y
-  mov r1.y, cb4[10].y
-  mov r1.z, cb4[11].y
-  dp3 r0.y, r1.xyzx, r2.xyzx
-  mov r1.x, cb4[9].z
-  mov r1.y, cb4[10].z
-  mov r1.z, cb4[11].z
-  dp3 r0.z, r1.xyzx, r2.xyzx
-  mov r1.x, cb4[9].w
-  mov r1.y, cb4[10].w
-  mov r1.z, cb4[11].w
-  mov r1.w, cb4[12].w
-  dp4 r1.x, r1.xyzw, r2.xyzw
-  eq r1.y, cb0[24].x, l(1.000000)
-  movc r1.yzw, r1.yyyy, v2.xxyz, v3.xxyz
-  mul r2.xyz, r1.zzzz, cb3[1].xyzx
-  mad r2.xyz, cb3[0].xyzx, r1.yyyy, r2.xyzx
-  mad r1.yzw, cb3[2].xxyz, r1.wwww, r2.xxyz
-  mul r2.xy, r1.zzzz, cb4[10].xyxx
-  mad r1.yz, cb4[9].xxyx, r1.yyyy, r2.xxyx
-  mad r2.xy, cb4[11].xyxx, r1.wwww, r1.yzyy
-  mov r2.z, l(0.010000)
-  dp3 r1.y, r2.xyzx, r2.xyzx
-  rsq r1.y, r1.y
-  mul r1.yz, r1.yyyy, r2.xxyx
-  div r1.w, l(2.414000), cb2[7].y
-  mul r2.x, -r0.z, r1.w
-  lt r2.x, r2.x, cb0[30].y
-  movc r3.xy, r2.xxxx, cb0[30].xyxx, cb0[30].yzyy
-  movc r3.zw, r2.xxxx, cb0[31].xxxy, cb0[31].yyyz
-  mad r1.w, -r0.z, r1.w, -r3.x
-  add r2.xy, -r3.xzxx, r3.ywyy
-  max r2.x, r2.x, l(0.001000)
-  div_sat r1.w, r1.w, r2.x
-  mad r1.w, r1.w, r2.y, r3.z
-  mul r2.x, cb0[26].x, cb0[54].w
-  mul r1.w, r1.w, r2.x
-  mul r1.w, r1.w, l(100.000000)
-  mul r1.w, r1.w, cb0[28].z
-  mul r1.w, r1.w, l(0.414250195)
-  mul r1.w, r1.w, v1.w
-  dp3 r2.x, r0.xyzx, r0.xyzx
-  rsq r2.x, r2.x
-  mul r2.xyz, r0.xyzx, r2.xxxx
-  mul r2.xyz, r2.xyzx, cb0[28].xxxx
-  mul r2.xyz, r2.xyzx, cb0[28].zzzz
-  add r2.w, v1.z, l(-0.500000)
-  mad r0.xyz, r2.xyzx, r2.wwww, r0.xyzx
-  mad r0.xy, r1.yzyy, r1.wwww, r0.xyxx
-  mul r2.xyzw, r0.yyyy, cb4[6].xyzw
-  mad r2.xyzw, cb4[5].xyzw, r0.xxxx, r2.xyzw
-  mad r2.xyzw, cb4[7].xyzw, r0.zzzz, r2.xyzw
-  mad r1.xyzw, cb4[8].xyzw, r1.xxxx, r2.xyzw
-  ne r0.x, l(0.000000, 0.000000, 0.000000, 0.000000), cb0[41].y
-  lt r0.y, cb0[41].z, l(0.950000)
-  and r0.y, r0.y, r0.x
-  mul r0.z, cb0[56].w, cb1[6].x
-  mul r2.x, r1.w, cb0[56].z
-  mul r2.y, r1.w, r0.z
-  mad r2.xy, r2.xyxx, l(2.000000, 2.000000, 0.000000, 0.000000), r1.xyxx
-  movc r1.xy, r0.yyyy, r2.xyxx, r1.xyxx
-  mov r2.xz, l(0.500000,0,0.500000,0)
-  mov r2.y, cb1[6].x
-  mul r2.xyz, r1.xywx, r2.xyzx
-  mul r2.w, r2.y, l(0.500000)
-  add r2.xy, r2.zzzz, r2.xwxx
-  mov r2.z, cb0[41].z
-  mov r2.w, r1.w
-  and o4.xyzw, r0.xxxx, r2.xyzw
-  mad o2.xy, v4.xyxx, cb0[40].xyxx, cb0[40].zwzz
-  mov o0.xyzw, r1.xyzw
-  mov o1.xyz, cb0[27].xyzx
-  mov o1.w, r0.w
-  mov o3.xyz, l(0,0,0,0)
-endif
-ret
-// Approximately 0 instruction slots used
-
-//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/

--- a/hic_sunt_dracones/OutlineHull_5_3.hlsl
+++ b/hic_sunt_dracones/OutlineHull_5_3.hlsl
@@ -1,0 +1,395 @@
+//  outline offset 4.6 LeoTorreZ   ---- Created with 3Dmigoto v1.3.16 on Tue Apr 23 23:44:55 2024
+cbuffer cb4 : register(b4)
+{
+  float4 cb4[13];
+}
+
+cbuffer cb3 : register(b3)
+{
+  float4 cb3[8];
+}
+
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[8];
+}
+
+cbuffer cb1 : register(b1)
+{
+  float4 cb1[7];
+}
+
+cbuffer cb0 : register(b0)
+{
+  float4 cb0[57];
+}
+
+
+
+
+// 3Dmigoto declarations
+#define cmp -
+Texture1D<float4> IniParams : register(t120);
+Texture2D<float4> StereoParams : register(t125);
+#define OFFSET IniParams[169].x
+
+
+void main(
+  float4 v0 : POSITION0,
+  float4 v1 : COLOR0,
+  float3 v2 : NORMAL0,
+  float4 v3 : TANGENT0,
+  float4 v4 : TEXCOORD0,
+  float2 v5 : TEXCOORD1,
+  out float4 o0 : SV_POSITION0,
+  out float4 o1 : COLOR0,
+  out float4 o2 : TEXCOORD0,
+  out float4 o3 : TEXCOORD1,
+  out float4 o4 : TEXCOORD2)
+{
+  float4 r0,r1,r2,r3,r4,r5;
+  uint4 bitmask, uiDest;
+  float4 fDest;
+  v1.zw = float2(0.0,0.0);
+  r5.xyzw = float4(0.0,0.0,0.0,0.0);
+  o0 = r5;
+  o1 = r5;
+  o2 = r5;
+  o3 = r5;
+  o4 = r5;
+
+  r0.x = cmp(cb0[24].x == 0.000000);
+  if (r0.x != 0) {
+    o0.xyzw = float4(0,0,0,0);
+    o1.xyzw = float4(0,0,0,0);
+    o4.xyzw = float4(0,0,0,0);
+    o3.xyz = float3(0,0,0);
+    o2.xy = float2(0,0);
+  }
+  if (r0.x == 0) {
+    r0.xy = cmp(float2(0,0) != cb0[36].yz);
+    r0.z = cmp(abs(cb0[37].w) < 0.00100000005);
+    r1.xyz = cb0[37].xyz * cb0[37].www;
+    r1.xyz = r0.zzz ? float3(0,0,0) : r1.xyz;
+    r2.xyzw = cb3[5].xyzw * r1.yyyy;
+    r2.xyzw = cb3[4].xyzw * r1.xxxx + r2.xyzw;
+    r1.xyzw = cb3[6].xyzw * r1.zzzz + r2.xyzw;
+    r1.xyzw = cb3[7].xyzw + r1.xyzw;
+    r1.xyz = r1.xyz / r1.www;
+    r2.xyz = cb3[5].xyz * cb0[37].yyy;
+    r2.xyz = cb3[4].xyz * cb0[37].xxx + r2.xyz;
+    r2.xyz = cb3[6].xyz * cb0[37].zzz + r2.xyz;
+    r0.z = dot(r1.xyz, r2.xyz);
+    r0.w = dot(v0.xyz, r2.xyz);
+    r1.x = cmp(r0.w < r0.z);
+    r0.z = r0.w + -r0.z;
+    r2.xyz = -r0.zzz * r2.xyz + v0.xyz;
+    r2.w = 0;
+    r3.xyz = v0.xyz;
+    r3.w = 1;
+    r1.xyzw = r1.xxxx ? r2.xyzw : r3.xyzw;
+    r0.z = dot(v0.xyz, cb0[37].xyz);
+    r0.w = -0.00999999978 + cb0[37].w;
+    r0.w = cmp(r0.z < r0.w);
+    r0.z = -cb0[37].w + r0.z;
+    r2.xyz = -r0.zzz * cb0[37].xyz + v0.xyz;
+    r2.w = 0;
+    r2.xyzw = r0.wwww ? r2.xyzw : r3.xyzw;
+    r1.xyzw = r0.yyyy ? r1.xyzw : r2.xyzw;
+    r0.xyzw = r0.xxxx ? r1.xyzw : r3.xyzw;
+    r1.xyw = cb3[3].xyz + -cb1[5].xyz;
+    r2.x = cb3[0].x;
+    r2.y = cb3[1].x;
+    r2.z = cb3[2].x;
+    r2.w = r1.x;
+    r3.xyz = r0.xyz;
+    r3.w = v0.w;
+    r2.x = dot(r2.xyzw, r3.xyzw);
+    r4.x = cb3[0].y;
+    r4.y = cb3[1].y;
+    r4.z = cb3[2].y;
+    r4.w = r1.y;
+    r2.y = dot(r4.xyzw, r3.xyzw);
+    r1.x = cb3[0].z;
+    r1.y = cb3[1].z;
+    r1.z = cb3[2].z;
+    r2.z = dot(r1.xyzw, r3.xyzw);
+    r1.x = cb3[0].w;
+    r1.y = cb3[1].w;
+    r1.z = cb3[2].w;
+    r1.w = cb3[3].w;
+    r2.w = dot(r1.xyzw, r3.xyzw);
+    r2.y = r2.y + OFFSET;
+    r0.x = cb4[9].x;
+    r0.y = cb4[10].x;
+    r0.z = cb4[11].x;
+    r0.x = dot(r0.xyz, r2.xyz);
+    r1.x = cb4[9].y;
+    r1.y = cb4[10].y;
+    r1.z = cb4[11].y;
+    r0.y = dot(r1.xyz, r2.xyz);
+    r1.x = cb4[9].z;
+    r1.y = cb4[10].z;
+    r1.z = cb4[11].z;
+    r0.z = dot(r1.xyz, r2.xyz);
+    r1.x = cb4[9].w;
+    r1.y = cb4[10].w;
+    r1.z = cb4[11].w;
+    r1.w = cb4[12].w;
+    r1.x = dot(r1.xyzw, r2.xyzw);
+    r1.y = cmp(cb0[24].x == 1.000000);
+    r1.yzw = r1.yyy ? v2.xyz : v3.xyz;
+    r2.xyz = cb3[1].xyz * r1.zzz;
+    r2.xyz = cb3[0].xyz * r1.yyy + r2.xyz;
+    r1.yzw = cb3[2].xyz * r1.www + r2.xyz;
+    r2.xy = cb4[10].xy * r1.zz;
+    r1.yz = cb4[9].xy * r1.yy + r2.xy;
+    r2.xy = cb4[11].xy * r1.ww + r1.yz;
+    r2.z = 0.00999999978;
+    r1.y = dot(r2.xyz, r2.xyz);
+    r1.y = rsqrt(r1.y);
+    r1.yz = r2.xy * r1.yy;
+    r1.w = 2.41400003 / cb2[7].y;
+    r2.x = r1.w * -r0.z;
+    r2.x = cmp(r2.x < cb0[30].y);
+    r3.xy = r2.xx ? cb0[30].xy : cb0[30].yz;
+    r3.zw = r2.xx ? cb0[31].xy : cb0[31].yz;
+    r1.w = -r0.z * r1.w + -r3.x;
+    r2.xy = r3.yw + -r3.xz;
+    r2.x = max(0.00100000005, r2.x);
+    r1.w = saturate(r1.w / r2.x);
+    r1.w = r1.w * r2.y + r3.z;
+    r2.x = cb0[54].w * cb0[26].x;
+    r1.w = r2.x * r1.w;
+    r1.w = 100 * r1.w;
+    r1.w = cb0[28].z * r1.w;
+    r1.w = 0.414250195 * r1.w;
+    r1.w = v1.w * r1.w;
+    r2.x = dot(r0.xyz, r0.xyz);
+    r2.x = rsqrt(r2.x);
+    r2.xyz = r2.xxx * r0.xyz;
+    r2.xyz = cb0[28].xxx * r2.xyz;
+    r2.xyz = cb0[28].zzz * r2.xyz;
+    r2.w = -0.5 + v1.z;
+    r0.xyz = r2.xyz * r2.www + r0.xyz;
+    r0.xy = r1.yz * r1.ww + r0.xy;
+    r2.xyzw = cb4[6].xyzw * r0.yyyy;
+    r2.xyzw = cb4[5].xyzw * r0.xxxx + r2.xyzw;
+    r2.xyzw = cb4[7].xyzw * r0.zzzz + r2.xyzw;
+    r1.xyzw = cb4[8].xyzw * r1.xxxx + r2.xyzw;
+    r0.x = cmp(0 != cb0[41].y);
+    r0.y = cmp(cb0[41].z < 0.949999988);
+    r0.y = r0.y ? r0.x : 0;
+    r0.z = cb1[6].x * cb0[56].w;
+    r2.x = cb0[56].z * r1.w;
+    r2.y = r0.z * r1.w;
+    r2.xy = r2.xy * float2(2,2) + r1.xy;
+    r1.xy = r0.yy ? r2.xy : r1.xy;
+    r2.xz = float2(0.5,0.5);
+    r2.y = cb1[6].x;
+    r2.xyz = r2.xyz * r1.xyw;
+    r2.w = 0.5 * r2.y;
+    r2.xy = r2.xw + r2.zz;
+    r2.z = cb0[41].z;
+    r2.w = r1.w;
+    o4.xyzw = r0.xxxx ? r2.xyzw : 0;
+    o2.xy = v4.xy * cb0[40].xy + cb0[40].zw;
+    o0.xyzw = r1.xyzw;
+    o1.xyz = cb0[27].xyz;
+    o1.w = r0.w;
+    o3.xyz = float3(0,0,0);
+  }
+  return;
+}
+
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Generated by Microsoft (R) D3D Shader Disassembler
+//
+//   using 3Dmigoto v1.3.16 on Tue Apr 23 23:44:55 2024
+//
+//
+// Input signature:
+//
+// Name                 Index   Mask Register SysValue  Format   Used
+// -------------------- ----- ------ -------- -------- ------- ------
+// POSITION                 0   xyzw        0     NONE   float   xyzw
+// COLOR                    0   xyzw        1     NONE   float     zw
+// NORMAL                   0   xyz         2     NONE   float   xyz
+// TANGENT                  0   xyzw        3     NONE   float   xyz
+// TEXCOORD                 0   xy          4     NONE   float   xy
+// TEXCOORD                 1   xy          5     NONE   float
+//
+//
+// Output signature:
+//
+// Name                 Index   Mask Register SysValue  Format   Used
+// -------------------- ----- ------ -------- -------- ------- ------
+// SV_POSITION              0   xyzw        0      POS   float   xyzw
+// COLOR                    0   xyzw        1     NONE   float   xyzw
+// TEXCOORD                 0   xy          2     NONE   float   xy
+// TEXCOORD                 1   xyz         3     NONE   float   xyz
+// TEXCOORD                 2   xyzw        4     NONE   float   xyzw
+//
+vs_5_0
+dcl_globalFlags refactoringAllowed
+dcl_constantbuffer CB0[57], immediateIndexed
+dcl_constantbuffer CB1[7], immediateIndexed
+dcl_constantbuffer CB2[8], immediateIndexed
+dcl_constantbuffer CB3[8], immediateIndexed
+dcl_constantbuffer CB4[13], immediateIndexed
+dcl_input v0.xyzw
+dcl_input v1.zw
+dcl_input v2.xyz
+dcl_input v3.xyz
+dcl_input v4.xy
+dcl_output_siv o0.xyzw, position
+dcl_output o1.xyzw
+dcl_output o2.xy
+dcl_output o3.xyz
+dcl_output o4.xyzw
+dcl_temps 5
+eq r0.x, cb0[24].x, l(0.000000)
+if_nz r0.x
+  mov o0.xyzw, l(0,0,0,0)
+  mov o1.xyzw, l(0,0,0,0)
+  mov o4.xyzw, l(0,0,0,0)
+  mov o3.xyz, l(0,0,0,0)
+  mov o2.xy, l(0,0,0,0)
+endif
+if_z r0.x
+  ne r0.xy, l(0.000000, 0.000000, 0.000000, 0.000000), cb0[36].yzyy
+  lt r0.z, |cb0[37].w|, l(0.001000)
+  mul r1.xyz, cb0[37].wwww, cb0[37].xyzx
+  movc r1.xyz, r0.zzzz, l(0,0,0,0), r1.xyzx
+  mul r2.xyzw, r1.yyyy, cb3[5].xyzw
+  mad r2.xyzw, cb3[4].xyzw, r1.xxxx, r2.xyzw
+  mad r1.xyzw, cb3[6].xyzw, r1.zzzz, r2.xyzw
+  add r1.xyzw, r1.xyzw, cb3[7].xyzw
+  div r1.xyz, r1.xyzx, r1.wwww
+  mul r2.xyz, cb0[37].yyyy, cb3[5].xyzx
+  mad r2.xyz, cb3[4].xyzx, cb0[37].xxxx, r2.xyzx
+  mad r2.xyz, cb3[6].xyzx, cb0[37].zzzz, r2.xyzx
+  dp3 r0.z, r1.xyzx, r2.xyzx
+  dp3 r0.w, v0.xyzx, r2.xyzx
+  lt r1.x, r0.w, r0.z
+  add r0.z, -r0.z, r0.w
+  mad r2.xyz, -r0.zzzz, r2.xyzx, v0.xyzx
+  mov r2.w, l(0)
+  mov r3.xyz, v0.xyzx
+  mov r3.w, l(1.000000)
+  movc r1.xyzw, r1.xxxx, r2.xyzw, r3.xyzw
+  dp3 r0.z, v0.xyzx, cb0[37].xyzx
+  add r0.w, cb0[37].w, l(-0.010000)
+  lt r0.w, r0.z, r0.w
+  add r0.z, r0.z, -cb0[37].w
+  mad r2.xyz, -r0.zzzz, cb0[37].xyzx, v0.xyzx
+  mov r2.w, l(0)
+  movc r2.xyzw, r0.wwww, r2.xyzw, r3.xyzw
+  movc r1.xyzw, r0.yyyy, r1.xyzw, r2.xyzw
+  movc r0.xyzw, r0.xxxx, r1.xyzw, r3.xyzw
+  add r1.xyw, -cb1[5].xyxz, cb3[3].xyxz
+  mov r2.x, cb3[0].x
+  mov r2.y, cb3[1].x
+  mov r2.z, cb3[2].x
+  mov r2.w, r1.x
+  mov r3.xyz, r0.xyzx
+  mov r3.w, v0.w
+  dp4 r2.x, r2.xyzw, r3.xyzw
+  mov r4.x, cb3[0].y
+  mov r4.y, cb3[1].y
+  mov r4.z, cb3[2].y
+  mov r4.w, r1.y
+  dp4 r2.y, r4.xyzw, r3.xyzw
+  mov r1.x, cb3[0].z
+  mov r1.y, cb3[1].z
+  mov r1.z, cb3[2].z
+  dp4 r2.z, r1.xyzw, r3.xyzw
+  mov r1.x, cb3[0].w
+  mov r1.y, cb3[1].w
+  mov r1.z, cb3[2].w
+  mov r1.w, cb3[3].w
+  dp4 r2.w, r1.xyzw, r3.xyzw
+  mov r0.x, cb4[9].x
+  mov r0.y, cb4[10].x
+  mov r0.z, cb4[11].x
+  dp3 r0.x, r0.xyzx, r2.xyzx
+  mov r1.x, cb4[9].y
+  mov r1.y, cb4[10].y
+  mov r1.z, cb4[11].y
+  dp3 r0.y, r1.xyzx, r2.xyzx
+  mov r1.x, cb4[9].z
+  mov r1.y, cb4[10].z
+  mov r1.z, cb4[11].z
+  dp3 r0.z, r1.xyzx, r2.xyzx
+  mov r1.x, cb4[9].w
+  mov r1.y, cb4[10].w
+  mov r1.z, cb4[11].w
+  mov r1.w, cb4[12].w
+  dp4 r1.x, r1.xyzw, r2.xyzw
+  eq r1.y, cb0[24].x, l(1.000000)
+  movc r1.yzw, r1.yyyy, v2.xxyz, v3.xxyz
+  mul r2.xyz, r1.zzzz, cb3[1].xyzx
+  mad r2.xyz, cb3[0].xyzx, r1.yyyy, r2.xyzx
+  mad r1.yzw, cb3[2].xxyz, r1.wwww, r2.xxyz
+  mul r2.xy, r1.zzzz, cb4[10].xyxx
+  mad r1.yz, cb4[9].xxyx, r1.yyyy, r2.xxyx
+  mad r2.xy, cb4[11].xyxx, r1.wwww, r1.yzyy
+  mov r2.z, l(0.010000)
+  dp3 r1.y, r2.xyzx, r2.xyzx
+  rsq r1.y, r1.y
+  mul r1.yz, r1.yyyy, r2.xxyx
+  div r1.w, l(2.414000), cb2[7].y
+  mul r2.x, -r0.z, r1.w
+  lt r2.x, r2.x, cb0[30].y
+  movc r3.xy, r2.xxxx, cb0[30].xyxx, cb0[30].yzyy
+  movc r3.zw, r2.xxxx, cb0[31].xxxy, cb0[31].yyyz
+  mad r1.w, -r0.z, r1.w, -r3.x
+  add r2.xy, -r3.xzxx, r3.ywyy
+  max r2.x, r2.x, l(0.001000)
+  div_sat r1.w, r1.w, r2.x
+  mad r1.w, r1.w, r2.y, r3.z
+  mul r2.x, cb0[26].x, cb0[54].w
+  mul r1.w, r1.w, r2.x
+  mul r1.w, r1.w, l(100.000000)
+  mul r1.w, r1.w, cb0[28].z
+  mul r1.w, r1.w, l(0.414250195)
+  mul r1.w, r1.w, v1.w
+  dp3 r2.x, r0.xyzx, r0.xyzx
+  rsq r2.x, r2.x
+  mul r2.xyz, r0.xyzx, r2.xxxx
+  mul r2.xyz, r2.xyzx, cb0[28].xxxx
+  mul r2.xyz, r2.xyzx, cb0[28].zzzz
+  add r2.w, v1.z, l(-0.500000)
+  mad r0.xyz, r2.xyzx, r2.wwww, r0.xyzx
+  mad r0.xy, r1.yzyy, r1.wwww, r0.xyxx
+  mul r2.xyzw, r0.yyyy, cb4[6].xyzw
+  mad r2.xyzw, cb4[5].xyzw, r0.xxxx, r2.xyzw
+  mad r2.xyzw, cb4[7].xyzw, r0.zzzz, r2.xyzw
+  mad r1.xyzw, cb4[8].xyzw, r1.xxxx, r2.xyzw
+  ne r0.x, l(0.000000, 0.000000, 0.000000, 0.000000), cb0[41].y
+  lt r0.y, cb0[41].z, l(0.950000)
+  and r0.y, r0.y, r0.x
+  mul r0.z, cb0[56].w, cb1[6].x
+  mul r2.x, r1.w, cb0[56].z
+  mul r2.y, r1.w, r0.z
+  mad r2.xy, r2.xyxx, l(2.000000, 2.000000, 0.000000, 0.000000), r1.xyxx
+  movc r1.xy, r0.yyyy, r2.xyxx, r1.xyxx
+  mov r2.xz, l(0.500000,0,0.500000,0)
+  mov r2.y, cb1[6].x
+  mul r2.xyz, r1.xywx, r2.xyzx
+  mul r2.w, r2.y, l(0.500000)
+  add r2.xy, r2.zzzz, r2.xwxx
+  mov r2.z, cb0[41].z
+  mov r2.w, r1.w
+  and o4.xyzw, r0.xxxx, r2.xyzw
+  mad o2.xy, v4.xyxx, cb0[40].xyxx, cb0[40].zwzz
+  mov o0.xyzw, r1.xyzw
+  mov o1.xyz, cb0[27].xyzx
+  mov o1.w, r0.w
+  mov o3.xyz, l(0,0,0,0)
+endif
+ret
+// Approximately 0 instruction slots used
+
+//~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/

--- a/hic_sunt_dracones/OutlinePixelShaderRegex.ini
+++ b/hic_sunt_dracones/OutlinePixelShaderRegex.ini
@@ -52,10 +52,11 @@ ret
 dcl_resource_texture1d (float,float,float,float) t120
 dcl_resource_texture2d (float,float,float,float) t69
 dcl_resource_texture2d (float,float,float,float) t70
-dcl_sampler s14, mode_default
 dcl_sampler s15, mode_default
 
 [ShaderRegexOutlineTransparency.Pattern.Replace]
+; Add a toggle :X so this can be enable/disabled.
+; discard_z l(0)\n
 ${MatchOutline}\n
 ${ModestyB}
 ${TillTexcord}\n
@@ -68,7 +69,7 @@ ld_indexable(texture1d)(float,float,float,float) ${ini}.xyzw, l(69,0), t120.xyzw
 if_z ${ini}.y\n
 \t	resinfo_indexable(texture2d)(float,float,float,float) ${dim}.xyyy, l(0), t70.xyyy\n
 \t	if_nz ${dim}.xy\n
-\t\t	sample_indexable(texture2d)(float,float,float,float) ${tex70}.xyzw, ${texcoord}.xyzw, t70.xyzw, s14\n
+\t\t	sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex70}.xyzw, ${texcoord}.xyzw, t70.xyzw, s15\n
 \t\t	mov ${color}, ${tex70}.xyzw\n
 ;\t\t	add ${tex70}.w, ${tex70}.w, -l(0.5)\n
 ;\t\t	max ${tex70}.w, ${tex70}.w, l(0.0)\n
@@ -81,7 +82,7 @@ if_z ${ini}.y\n
 ; TexFx Discard Outlines
 \t	resinfo_indexable(texture2d)(float,float,float,float) ${dim}.xyzw, l(0), t69.xyzw\n
 \t	if_nz ${dim}.xy\n
-\t\t	sample_indexable(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
+\t\t	sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
 ; Green Channel
 ;
 ; Blue Channel

--- a/hic_sunt_dracones/OutlinePixelShaderRegex.ini
+++ b/hic_sunt_dracones/OutlinePixelShaderRegex.ini
@@ -42,7 +42,7 @@ dcl_output o5\.x\n
 ^\s+mad -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, l\(-?\d*\.?\d+\), -?r\d+\.\w+\n
 ^\s+add -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n
 ^\s+lt -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n.*)
-(?P<TillTexcord>sample_[b_]{0,2}indexable\(texture2d\)\(float,float,float,float\) r\d\d?\.[xyzw]+, (?P<TexcoordX>[rv]\d\d?\.[xy][yz][xy][xy]), t[012].[xyzw]+, s\d(, \w\d+(\.[xyzw]+)?)?$)
+(?P<TillTexcord>sample_[b_]{0,2}indexable\(texture2d\)\(float,float,float,float\) r\d\d?\.[xyzw]+, (?P<TexcoordX>[r]\d\d?\.[xy][yz][xy][xy]), t[012].[xyzw]+, s\d(, \w\d+(\.[xyzw]+)?)?$)
 (?P<TillSetColor>.*else\s*mov (?P<color>r\d\.[xyzw]+), v\d\.[xyzw]+.*endif)
 (?P<TillRet>.*)
 ret

--- a/hic_sunt_dracones/OutlinePixelShaderRegex53.ini
+++ b/hic_sunt_dracones/OutlinePixelShaderRegex53.ini
@@ -2,7 +2,7 @@ namespace = TexFx
 
 [ShaderRegexOutlineTransparency53]
 shader_model = ps_4_0 ps_5_0
-filter_index = 037730.553
+filter_index = 037730.533
 temps = ini tex69 tex70 dim texcoord
 if ps-t69 === 0 && $texfx_on
 	run = CommandListSwapVersion53

--- a/hic_sunt_dracones/OutlinePixelShaderRegex53.ini
+++ b/hic_sunt_dracones/OutlinePixelShaderRegex53.ini
@@ -1,0 +1,103 @@
+; namespace = TexFx
+
+; [ShaderRegexOutlineTransparency]
+; shader_model = ps_4_0 ps_5_0
+; filter_index = 037730.555
+; temps = ini tex69 tex70 dim texcoord
+; if ps-t69 === 0 && $texfx_on
+; 	run = CommandListSwapVersion
+; 	run = CommandListClearInstanceValues
+; 	run = CommandListResetResources
+; endif
+; ;run = CommandListClearInstanceValues
+; if ps-t70 === 0
+; 	post ps-t70 = null
+; endif
+
+; ; Regex Match ---------------------------------------
+; ;Match Outline
+; [ShaderRegexOutlineTransparency.Pattern]
+; (?s)(?P<MatchOutline>
+; dcl_output o0\.xyzw\n
+; dcl_output o1\.xyzw\n
+; dcl_output o2\.xyzw\n
+; dcl_output o3\.x\n
+; dcl_output o4\.x\n
+; dcl_output o5\.x\n
+; .*)
+; (?P<ModestyB>^\s+if_nz -?r\d+\.\w+\n
+; ^\s+div -?r\d+\.\w+, v?\d+\.\w+, v?\d+\.\w+\n
+; ^\s+mul -?r\d+\.\w+, -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+\n
+; ^\s+mul -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+, -?\d*\.?\d+, -?\d*\.?\d+, -?\d*\.?\d+\)\n
+; ^\s+ge -?r\d+\.\w+, -?r\d+\.\w+, -?r\d+\.\w+\n
+; ^\s+frc -?r\d+\.\w+, \|-?r\d+\.\w+\|\n
+; ^\s+movc -?r\d+\.\w+, -?r\d+\.\w+, -?r\d+\.\w+, -?r\d+\.\w+\n
+; ^\s+mul -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+, -?\d*\.?\d+, -?\d*\.?\d+, -?\d*\.?\d+\)\n
+; ^\s+ftou -?r\d+\.\w+, -?r\d+\.\w+\n
+; ^\s+dp\d+\ -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
+; ^\s+dp\d+\ -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
+; ^\s+dp\d+\ -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
+; ^\s+dp\d+\ -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
+; ^\s+dp\d+\ r\d+\.\w+, -?r\d+\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
+; ^\s+mad -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, l\(-?\d*\.?\d+\), -?r\d+\.\w+\n
+; ^\s+add -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n
+; ^\s+lt -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n.*)
+; (?P<TillTexcord>sample_[b_]{0,2}indexable\(texture2d\)\(float,float,float,float\) r\d\d?\.[xyzw]+, (?P<TexcoordX>[rv]\d\d?\.[xy][yz][xy][xy]), t[012].[xyzw]+, s\d(, \w\d+(\.[xyzw]+)?)?$)
+; (?P<TillSetColor>.*else\s*mov (?P<color>r\d\.[xyzw]+), v\d\.[xyzw]+.*endif)
+; (?P<TillRet>.*)
+; ret
+
+; [ShaderRegexOutlineTransparency.InsertDeclarations]
+; ;dcl_input_ps_sgv constant v15.x, is_front_face
+; dcl_resource_texture1d (float,float,float,float) t120
+; dcl_resource_texture2d (float,float,float,float) t69
+; dcl_resource_texture2d (float,float,float,float) t70
+; dcl_sampler s15, mode_default
+
+; [ShaderRegexOutlineTransparency.Pattern.Replace]
+; ; Add a toggle :X so this can be enable/disabled.
+; ; discard_z l(0)\n
+; ${MatchOutline}\n
+; ${ModestyB}
+; ${TillTexcord}\n
+; mov ${texcoord}.xyzw, ${TexcoordX}\n
+; ${TillSetColor}\n
+; ; debugging, set constant outline color
+
+; ; Custom Outline Colors, Sponsered by Annplan.
+; ld_indexable(texture1d)(float,float,float,float) ${ini}.xyzw, l(69,0), t120.xyzw\n
+; if_z ${ini}.y\n
+; \t	resinfo_indexable(texture2d)(float,float,float,float) ${dim}.xyyy, l(0), t70.xyyy\n
+; \t	if_nz ${dim}.xy\n
+; \t\t	sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex70}.xyzw, ${texcoord}.xyzw, t70.xyzw, s15\n
+; \t\t	mov ${color}, ${tex70}.xyzw\n
+; ;\t\t	add ${tex70}.w, ${tex70}.w, -l(0.5)\n
+; ;\t\t	max ${tex70}.w, ${tex70}.w, l(0.0)\n
+; ;\t\t	discard_z ${tex70}.w\n
+; \t	endif\n
+; endif\n
+; ; mov ${color}, l(0.1,0.2,0.3,1.0)\n
+; ${TillRet}
+; if_z ${ini}.y\n
+; ; TexFx Discard Outlines
+; \t	resinfo_indexable(texture2d)(float,float,float,float) ${dim}.xyzw, l(0), t69.xyzw\n
+; \t	if_nz ${dim}.xy\n
+; \t\t	sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
+; ; Green Channel
+; ;
+; ; Blue Channel
+; ;
+; ; Red Channel
+; \t\t	if_nz ${ini}.w\n
+; \t\t\t		add ${tex69}.x, ${tex69}.x, l(-1.0)\n
+; \t\t\t		discard_z ${tex69}.x\n
+; \t\t	endif\n
+; \t\t	if_z ${ini}.w\n
+; \t\t\t		discard_nz ${tex69}.x\n
+; ;\t\t\t		discard_nz v15.x\n
+; \t\t	endif\n
+; \t	endif\n
+; endif\n
+; ; debugging, remove outline
+; ; discard_z l(0)\n
+; ret

--- a/hic_sunt_dracones/OutlinePixelShaderRegex53.ini
+++ b/hic_sunt_dracones/OutlinePixelShaderRegex53.ini
@@ -1,103 +1,103 @@
-; namespace = TexFx
+namespace = TexFx
 
-; [ShaderRegexOutlineTransparency]
-; shader_model = ps_4_0 ps_5_0
-; filter_index = 037730.555
-; temps = ini tex69 tex70 dim texcoord
-; if ps-t69 === 0 && $texfx_on
-; 	run = CommandListSwapVersion
-; 	run = CommandListClearInstanceValues
-; 	run = CommandListResetResources
-; endif
-; ;run = CommandListClearInstanceValues
-; if ps-t70 === 0
-; 	post ps-t70 = null
-; endif
+[ShaderRegexOutlineTransparency53]
+shader_model = ps_4_0 ps_5_0
+filter_index = 037730.553
+temps = ini tex69 tex70 dim texcoord
+if ps-t69 === 0 && $texfx_on
+	run = CommandListSwapVersion53
+	run = CommandListClearInstanceValues
+	run = CommandListResetResources
+endif
+;run = CommandListClearInstanceValues
+if ps-t70 === 0
+	post ps-t70 = null
+endif
 
-; ; Regex Match ---------------------------------------
-; ;Match Outline
-; [ShaderRegexOutlineTransparency.Pattern]
-; (?s)(?P<MatchOutline>
-; dcl_output o0\.xyzw\n
-; dcl_output o1\.xyzw\n
-; dcl_output o2\.xyzw\n
-; dcl_output o3\.x\n
-; dcl_output o4\.x\n
-; dcl_output o5\.x\n
-; .*)
-; (?P<ModestyB>^\s+if_nz -?r\d+\.\w+\n
-; ^\s+div -?r\d+\.\w+, v?\d+\.\w+, v?\d+\.\w+\n
-; ^\s+mul -?r\d+\.\w+, -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+\n
-; ^\s+mul -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+, -?\d*\.?\d+, -?\d*\.?\d+, -?\d*\.?\d+\)\n
-; ^\s+ge -?r\d+\.\w+, -?r\d+\.\w+, -?r\d+\.\w+\n
-; ^\s+frc -?r\d+\.\w+, \|-?r\d+\.\w+\|\n
-; ^\s+movc -?r\d+\.\w+, -?r\d+\.\w+, -?r\d+\.\w+, -?r\d+\.\w+\n
-; ^\s+mul -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+, -?\d*\.?\d+, -?\d*\.?\d+, -?\d*\.?\d+\)\n
-; ^\s+ftou -?r\d+\.\w+, -?r\d+\.\w+\n
-; ^\s+dp\d+\ -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
-; ^\s+dp\d+\ -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
-; ^\s+dp\d+\ -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
-; ^\s+dp\d+\ -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
-; ^\s+dp\d+\ r\d+\.\w+, -?r\d+\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
-; ^\s+mad -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, l\(-?\d*\.?\d+\), -?r\d+\.\w+\n
-; ^\s+add -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n
-; ^\s+lt -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n.*)
-; (?P<TillTexcord>sample_[b_]{0,2}indexable\(texture2d\)\(float,float,float,float\) r\d\d?\.[xyzw]+, (?P<TexcoordX>[rv]\d\d?\.[xy][yz][xy][xy]), t[012].[xyzw]+, s\d(, \w\d+(\.[xyzw]+)?)?$)
-; (?P<TillSetColor>.*else\s*mov (?P<color>r\d\.[xyzw]+), v\d\.[xyzw]+.*endif)
-; (?P<TillRet>.*)
-; ret
+; Regex Match ---------------------------------------
+;Match Outline
+[ShaderRegexOutlineTransparency53.Pattern]
+(?s)(?P<MatchOutline>
+dcl_output o0\.xyzw\n
+dcl_output o1\.xyzw\n
+dcl_output o2\.xyzw\n
+dcl_output o3\.x\n
+dcl_output o4\.x\n
+dcl_output o5\.x\n
+.*)
+(?P<ModestyB>^\s+if_nz -?r\d+\.\w+\n
+^\s+div -?r\d+\.\w+, v?\d+\.\w+, v?\d+\.\w+\n
+^\s+mul -?r\d+\.\w+, -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+\n
+^\s+mul -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+, -?\d*\.?\d+, -?\d*\.?\d+, -?\d*\.?\d+\)\n
+^\s+ge -?r\d+\.\w+, -?r\d+\.\w+, -?r\d+\.\w+\n
+^\s+frc -?r\d+\.\w+, \|-?r\d+\.\w+\|\n
+^\s+movc -?r\d+\.\w+, -?r\d+\.\w+, -?r\d+\.\w+, -?r\d+\.\w+\n
+^\s+mul -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+, -?\d*\.?\d+, -?\d*\.?\d+, -?\d*\.?\d+\)\n
+^\s+ftou -?r\d+\.\w+, -?r\d+\.\w+\n
+^\s+dp\d+\ -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
+^\s+dp\d+\ -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
+^\s+dp\d+\ -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
+^\s+dp\d+\ -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
+^\s+dp\d+\ r\d+\.\w+, -?r\d+\.\w+, icb\[r\d+\.\w+ \+.?\d+\]\.\w+\n
+^\s+mad -?r\d+\.\w+, -?cb\d\[\d+\]\.\w+, l\(-?\d*\.?\d+\), -?r\d+\.\w+\n
+^\s+add -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n
+^\s+lt -?r\d+\.\w+, -?r\d+\.\w+, l\(-?\d*\.?\d+\)\n.*)
+(?P<TillTexcord>sample_[b_]{0,2}indexable\(texture2d\)\(float,float,float,float\) r\d\d?\.[xyzw]+, (?P<TexcoordX>[v]\d\d?\.[xy][yz][xy][xy]), t[012].[xyzw]+, s\d(, \w\d+(\.[xyzw]+)?)?$)
+(?P<TillSetColor>.*else\s*mov (?P<color>r\d\.[xyzw]+), v\d\.[xyzw]+.*endif)
+(?P<TillRet>.*)
+ret
 
-; [ShaderRegexOutlineTransparency.InsertDeclarations]
-; ;dcl_input_ps_sgv constant v15.x, is_front_face
-; dcl_resource_texture1d (float,float,float,float) t120
-; dcl_resource_texture2d (float,float,float,float) t69
-; dcl_resource_texture2d (float,float,float,float) t70
-; dcl_sampler s15, mode_default
+[ShaderRegexOutlineTransparency53.InsertDeclarations]
+;dcl_input_ps_sgv constant v15.x, is_front_face
+dcl_resource_texture1d (float,float,float,float) t120
+dcl_resource_texture2d (float,float,float,float) t69
+dcl_resource_texture2d (float,float,float,float) t70
+dcl_sampler s15, mode_default
 
-; [ShaderRegexOutlineTransparency.Pattern.Replace]
-; ; Add a toggle :X so this can be enable/disabled.
-; ; discard_z l(0)\n
-; ${MatchOutline}\n
-; ${ModestyB}
-; ${TillTexcord}\n
-; mov ${texcoord}.xyzw, ${TexcoordX}\n
-; ${TillSetColor}\n
-; ; debugging, set constant outline color
+[ShaderRegexOutlineTransparency53.Pattern.Replace]
+; Add a toggle :X so this can be enable/disabled.
+; discard_z l(0)\n
+${MatchOutline}\n
+${ModestyB}
+${TillTexcord}\n
+mov ${texcoord}.xyzw, ${TexcoordX}\n
+${TillSetColor}\n
+; debugging, set constant outline color
 
-; ; Custom Outline Colors, Sponsered by Annplan.
-; ld_indexable(texture1d)(float,float,float,float) ${ini}.xyzw, l(69,0), t120.xyzw\n
-; if_z ${ini}.y\n
-; \t	resinfo_indexable(texture2d)(float,float,float,float) ${dim}.xyyy, l(0), t70.xyyy\n
-; \t	if_nz ${dim}.xy\n
-; \t\t	sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex70}.xyzw, ${texcoord}.xyzw, t70.xyzw, s15\n
-; \t\t	mov ${color}, ${tex70}.xyzw\n
-; ;\t\t	add ${tex70}.w, ${tex70}.w, -l(0.5)\n
-; ;\t\t	max ${tex70}.w, ${tex70}.w, l(0.0)\n
-; ;\t\t	discard_z ${tex70}.w\n
-; \t	endif\n
-; endif\n
-; ; mov ${color}, l(0.1,0.2,0.3,1.0)\n
-; ${TillRet}
-; if_z ${ini}.y\n
-; ; TexFx Discard Outlines
-; \t	resinfo_indexable(texture2d)(float,float,float,float) ${dim}.xyzw, l(0), t69.xyzw\n
-; \t	if_nz ${dim}.xy\n
-; \t\t	sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
-; ; Green Channel
-; ;
-; ; Blue Channel
-; ;
-; ; Red Channel
-; \t\t	if_nz ${ini}.w\n
-; \t\t\t		add ${tex69}.x, ${tex69}.x, l(-1.0)\n
-; \t\t\t		discard_z ${tex69}.x\n
-; \t\t	endif\n
-; \t\t	if_z ${ini}.w\n
-; \t\t\t		discard_nz ${tex69}.x\n
-; ;\t\t\t		discard_nz v15.x\n
-; \t\t	endif\n
-; \t	endif\n
-; endif\n
-; ; debugging, remove outline
-; ; discard_z l(0)\n
-; ret
+; Custom Outline Colors, Sponsered by Annplan.
+ld_indexable(texture1d)(float,float,float,float) ${ini}.xyzw, l(69,0), t120.xyzw\n
+if_z ${ini}.y\n
+\t	resinfo_indexable(texture2d)(float,float,float,float) ${dim}.xyyy, l(0), t70.xyyy\n
+\t	if_nz ${dim}.xy\n
+\t\t	sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex70}.xyzw, ${texcoord}.xyzw, t70.xyzw, s15\n
+\t\t	mov ${color}, ${tex70}.xyzw\n
+;\t\t	add ${tex70}.w, ${tex70}.w, -l(0.5)\n
+;\t\t	max ${tex70}.w, ${tex70}.w, l(0.0)\n
+;\t\t	discard_z ${tex70}.w\n
+\t	endif\n
+endif\n
+; mov ${color}, l(0.1,0.2,0.3,1.0)\n
+${TillRet}
+if_z ${ini}.y\n
+; TexFx Discard Outlines
+\t	resinfo_indexable(texture2d)(float,float,float,float) ${dim}.xyzw, l(0), t69.xyzw\n
+\t	if_nz ${dim}.xy\n
+\t\t	sample_aoffimmi_indexable(1,1,1)(texture2d)(float,float,float,float) ${tex69}.xyzw, ${texcoord}.xyzw, t69.xyzw, s15\n
+; Green Channel
+;
+; Blue Channel
+;
+; Red Channel
+\t\t	if_nz ${ini}.w\n
+\t\t\t		add ${tex69}.x, ${tex69}.x, l(-1.0)\n
+\t\t\t		discard_z ${tex69}.x\n
+\t\t	endif\n
+\t\t	if_z ${ini}.w\n
+\t\t\t		discard_nz ${tex69}.x\n
+;\t\t\t		discard_nz v15.x\n
+\t\t	endif\n
+\t	endif\n
+endif\n
+; debugging, remove outline
+; discard_z l(0)\n
+ret

--- a/hic_sunt_dracones/OutlineWithDiffuseColor0.hlsl
+++ b/hic_sunt_dracones/OutlineWithDiffuseColor0.hlsl
@@ -121,38 +121,38 @@ void main(
   r1 = float4(0,0,0,0);
   r0.x = -((int)frontfacing.x == 0);
   r0.y = r0.y ? r0.x : 0;
-  r0.yz = r0.yy ? v2.zw : v2.xy;
-  texco = v6.xy;
+  texco = !r0.yy ? v6.xy : v6.zw;
+  //if (frontfacing) discard;
 //Re-enable Modesty
-  r0.x = -(0 != cb0[133].y);
-  if (r0.x != 0) {
-    if (uncensor == 2){
-      r0.x = -(cb0[133].z < 0.1);
-    }else{
-      r0.x = -(cb0[133].z < 0.949999988);
-    }
-    if (r0.x != 0) {
-      r0.xy = v3.yx / v3.ww;
-      r0.xy = cb1[7].yx * r0.xy;
-      r0.xy = float2(0.25,0.25) * r0.xy;
-      r0.zw = -(r0.xy >= -r0.xy);
-      r0.xy = frac(abs(r0.xy));
-      r0.xy = r0.zw ? r0.xy : -r0.xy;
-      r0.xy = float2(4,4) * r0.xy;
-      r0.xy = (uint2)r0.xy;
-      r1.x = dot(cb0[17].xyzw, icb[r0.y+0].xyzw);
-      r1.y = dot(cb0[18].xyzw, icb[r0.y+0].xyzw);
-      r1.z = dot(cb0[19].xyzw, icb[r0.y+0].xyzw);
-      r1.w = dot(cb0[20].xyzw, icb[r0.y+0].xyzw);
-      r0.x = dot(r1.xyzw, icb[r0.x+0].xyzw);
-      r0.x = cb0[134].z * 17 + -r0.x;
-      r0.x = -0.00999999978 + r0.x;
-      r0.x = -(r0.x < 0);
-      if (uncensor != 0.0){
-        if (r0.x != 0) discard;
-      }
-    }
-  }
+  // r0.x = -(0 != cb0[133].y);
+  // if (r0.x != 0) {
+  //   if (uncensor == 2){
+  //     r0.x = -(cb0[133].z < 0.1);
+  //   }else{
+  //     r0.x = -(cb0[133].z < 0.949999988);
+  //   }
+  //   if (r0.x != 0) {
+  //     r0.xy = v3.yx / v3.ww;
+  //     r0.xy = cb1[7].yx * r0.xy;
+  //     r0.xy = float2(0.25,0.25) * r0.xy;
+  //     r0.zw = -(r0.xy >= -r0.xy);
+  //     r0.xy = frac(abs(r0.xy));
+  //     r0.xy = r0.zw ? r0.xy : -r0.xy;
+  //     r0.xy = float2(4,4) * r0.xy;
+  //     r0.xy = (uint2)r0.xy;
+  //     r1.x = dot(cb0[17].xyzw, icb[r0.y+0].xyzw);
+  //     r1.y = dot(cb0[18].xyzw, icb[r0.y+0].xyzw);
+  //     r1.z = dot(cb0[19].xyzw, icb[r0.y+0].xyzw);
+  //     r1.w = dot(cb0[20].xyzw, icb[r0.y+0].xyzw);
+  //     r0.x = dot(r1.xyzw, icb[r0.x+0].xyzw);
+  //     r0.x = cb0[133].z * 17 + -r0.x;
+  //     r0.x = -0.00999999978 + r0.x;
+  //     r0.x = -(r0.x < 0);
+  //     if (uncensor != 0.0){
+  //       if (r0.x != 0) discard;
+  //     }
+  //   }
+  // }
 //End Modesty
   float2 dims;
   //t69.GetDimensions(dims.x, dims.y);

--- a/hic_sunt_dracones/OutlineWithDiffuseColor0_5_3.hlsl
+++ b/hic_sunt_dracones/OutlineWithDiffuseColor0_5_3.hlsl
@@ -41,14 +41,19 @@ SamplerState s1_s : register(s1);
 
 SamplerState s0_s : register(s0);
 
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[17];
+}
+
 cbuffer cb1 : register(b1)
 {
-  float4 cb1[8];
+  float4 cb1[10];
 }
 
 cbuffer cb0 : register(b0)
 {
-  float4 cb0[160];
+  float4 cb0[90];
 }
 
 // #MARK: --- HSV CODE ---
@@ -92,13 +97,10 @@ void main(
   float4 v1 : COLOR0,
   float4 v2 : TEXCOORD0,
   float4 v3 : TEXCOORD1,
-  float4 v4 : TEXCOORD3,
-  float4 v5 : TEXCOORD4,
-  float4 v6 : TEXCOORD5,
-  float4 v7 : TEXCOORD6,
-  float4 v8 : TEXCOORD7,
-  float4 v9 : TEXCOORD8,
-  uint frontfacing : SV_IsFrontFace0,
+  float4 v4 : TEXCOORD2,
+  float4 v5 : TEXCOORD3,
+  float2 v6 : TEXCOORD4,
+  uint v7 : SV_IsFrontFace0,
   out float4 o0 : SV_Target0,
   out float4 o1 : SV_Target1,
   out float4 o2 : SV_Target2,
@@ -119,20 +121,26 @@ void main(
 
   r0 = float4(0,0,0,0);
   r1 = float4(0,0,0,0);
-  r0.x = -((int)frontfacing.x == 0);
+  r0.x = -((int)v7.x == 0);
   r0.y = r0.y ? r0.x : 0;
   r0.yz = r0.yy ? v2.zw : v2.xy;
-  texco = v6.xy;
+  texco = r0.yz;
 //Re-enable Modesty
-  r0.x = -(0 != cb0[133].y);
+  r1.xyz = v7.xxx ? v3.xyz : -v3.xyz;
+  r0.x = -(0 != cb0[36].y);
+  r0.y = -0.00999999978 + v1.w;
+  r0.y = -(r0.y < 0);
+  r0.x = r0.x ? r0.y : 0;
+  if (r0.x != 0) discard;
+  r0.x = -(0 != cb0[41].y);
   if (r0.x != 0) {
     if (uncensor == 2){
-      r0.x = -(cb0[133].z < 0.1);
+      r0.x = -(cb0[41].z < 0.1);
     }else{
-      r0.x = -(cb0[133].z < 0.949999988);
+      r0.x = -(cb0[41].z < 0.949999988);
     }
     if (r0.x != 0) {
-      r0.xy = v3.yx / v3.ww;
+      r0.xy = v4.yx / v4.ww;
       r0.xy = cb1[7].yx * r0.xy;
       r0.xy = float2(0.25,0.25) * r0.xy;
       r0.zw = -(r0.xy >= -r0.xy);
@@ -145,7 +153,7 @@ void main(
       r1.z = dot(cb0[19].xyzw, icb[r0.y+0].xyzw);
       r1.w = dot(cb0[20].xyzw, icb[r0.y+0].xyzw);
       r0.x = dot(r1.xyzw, icb[r0.x+0].xyzw);
-      r0.x = cb0[134].z * 17 + -r0.x;
+      r0.x = cb0[41].z * 17 + -r0.x;
       r0.x = -0.00999999978 + r0.x;
       r0.x = -(r0.x < 0);
       if (uncensor != 0.0){
@@ -153,6 +161,12 @@ void main(
       }
     }
   }
+  r0.x = t0.Sample(s0_s, texco, int2(1,1)).w;
+  r0.y = -(cb0[39].x == 1.000000);
+  r0.x = -cb0[39].y + r0.x;
+  r0.x = -(r0.x < 0);
+  r0.x = r0.y ? r0.x : 0;
+  if (r0.x != 0) discard;
 //End Modesty
   float2 dims;
   //t69.GetDimensions(dims.x, dims.y);

--- a/hic_sunt_dracones/OutlineWithDiffuseColor1.hlsl
+++ b/hic_sunt_dracones/OutlineWithDiffuseColor1.hlsl
@@ -120,38 +120,37 @@ void main(
   r1 = float4(0,0,0,0);
   r0.x = -((int)v7.x == 0);
   r0.y = r0.y ? r0.x : 0;
-  r0.yz = r0.yy ? v2.zw : v2.xy;
-  texco = v6.xy;
+  texco = !r0.yy ? v6.xy : v6.zw;
 //Re-enable Modesty
-  r0.x = -(0 != cb0[133].y);
-  if (r0.x != 0) {
-    if (uncensor == 2){
-      r0.x = -(cb0[133].z < 0.1);
-    }else{
-      r0.x = -(cb0[133].z < 0.949999988);
-    }
-    if (r0.x != 0) {
-      r0.xy = v3.yx / v3.ww;
-      r0.xy = cb1[7].yx * r0.xy;
-      r0.xy = float2(0.25,0.25) * r0.xy;
-      r0.zw = -(r0.xy >= -r0.xy);
-      r0.xy = frac(abs(r0.xy));
-      r0.xy = r0.zw ? r0.xy : -r0.xy;
-      r0.xy = float2(4,4) * r0.xy;
-      r0.xy = (uint2)r0.xy;
-      r1.x = dot(cb0[17].xyzw, icb[r0.y+0].xyzw);
-      r1.y = dot(cb0[18].xyzw, icb[r0.y+0].xyzw);
-      r1.z = dot(cb0[19].xyzw, icb[r0.y+0].xyzw);
-      r1.w = dot(cb0[20].xyzw, icb[r0.y+0].xyzw);
-      r0.x = dot(r1.xyzw, icb[r0.x+0].xyzw);
-      r0.x = cb0[133].z * 17 + -r0.x;
-      r0.x = -0.00999999978 + r0.x;
-      r0.x = -(r0.x < 0);
-      if (uncensor != 0.0){
-        if (r0.x != 0) discard;
-      }
-    }
-  }
+  // r0.x = -(0 != cb0[133].y);
+  // if (r0.x != 0) {
+  //   if (uncensor == 2){
+  //     r0.x = -(cb0[133].z < 0.1);
+  //   }else{
+  //     r0.x = -(cb0[133].z < 0.949999988);
+  //   }
+  //   if (r0.x != 0) {
+  //     r0.xy = v3.yx / v3.ww;
+  //     r0.xy = cb1[7].yx * r0.xy;
+  //     r0.xy = float2(0.25,0.25) * r0.xy;
+  //     r0.zw = -(r0.xy >= -r0.xy);
+  //     r0.xy = frac(abs(r0.xy));
+  //     r0.xy = r0.zw ? r0.xy : -r0.xy;
+  //     r0.xy = float2(4,4) * r0.xy;
+  //     r0.xy = (uint2)r0.xy;
+  //     r1.x = dot(cb0[17].xyzw, icb[r0.y+0].xyzw);
+  //     r1.y = dot(cb0[18].xyzw, icb[r0.y+0].xyzw);
+  //     r1.z = dot(cb0[19].xyzw, icb[r0.y+0].xyzw);
+  //     r1.w = dot(cb0[20].xyzw, icb[r0.y+0].xyzw);
+  //     r0.x = dot(r1.xyzw, icb[r0.x+0].xyzw);
+  //     r0.x = cb0[133].z * 17 + -r0.x;
+  //     r0.x = -0.00999999978 + r0.x;
+  //     r0.x = -(r0.x < 0);
+  //     if (uncensor != 0.0){
+  //       if (r0.x != 0) discard;
+  //     }
+  //   }
+  // }
 //End Modesty
   float2 dims;
   //t69.GetDimensions(dims.x, dims.y);

--- a/hic_sunt_dracones/OutlineWithDiffuseColor1.hlsl
+++ b/hic_sunt_dracones/OutlineWithDiffuseColor1.hlsl
@@ -40,19 +40,14 @@ SamplerState s1_s : register(s1);
 
 SamplerState s0_s : register(s0);
 
-cbuffer cb2 : register(b2)
-{
-  float4 cb2[17];
-}
-
 cbuffer cb1 : register(b1)
 {
-  float4 cb1[10];
+  float4 cb1[8];
 }
 
 cbuffer cb0 : register(b0)
 {
-  float4 cb0[90];
+  float4 cb0[160];
 }
 
 // #MARK: --- HSV CODE ---
@@ -96,10 +91,13 @@ void main(
   float4 v1 : COLOR0,
   float4 v2 : TEXCOORD0,
   float4 v3 : TEXCOORD1,
-  float4 v4 : TEXCOORD2,
-  float4 v5 : TEXCOORD3,
-  float2 v6 : TEXCOORD4,
-  uint v7 : SV_IsFrontFace0,
+  float4 v4 : TEXCOORD3,
+  float4 v5 : TEXCOORD4,
+  float4 v6 : TEXCOORD5,
+  float4 v7 : TEXCOORD6,
+  float4 v8 : TEXCOORD7,
+  float4 v9 : TEXCOORD8,
+  uint frontfacing : SV_IsFrontFace0,
   out float4 o0 : SV_Target0,
   out float4 o1 : SV_Target1,
   out float4 o2 : SV_Target2,
@@ -123,23 +121,17 @@ void main(
   r0.x = -((int)v7.x == 0);
   r0.y = r0.y ? r0.x : 0;
   r0.yz = r0.yy ? v2.zw : v2.xy;
-  texco = r0.yz;
+  texco = v6.xy;
 //Re-enable Modesty
-  r1.xyz = v7.xxx ? v3.xyz : -v3.xyz;
-  r0.x = -(0 != cb0[36].y);
-  r0.y = -0.00999999978 + v1.w;
-  r0.y = -(r0.y < 0);
-  r0.x = r0.x ? r0.y : 0;
-  if (r0.x != 0) discard;
-  r0.x = -(0 != cb0[41].y);
+  r0.x = -(0 != cb0[133].y);
   if (r0.x != 0) {
     if (uncensor == 2){
-      r0.x = -(cb0[41].z < 0.1);
+      r0.x = -(cb0[133].z < 0.1);
     }else{
-      r0.x = -(cb0[41].z < 0.949999988);
+      r0.x = -(cb0[133].z < 0.949999988);
     }
     if (r0.x != 0) {
-      r0.xy = v4.yx / v4.ww;
+      r0.xy = v3.yx / v3.ww;
       r0.xy = cb1[7].yx * r0.xy;
       r0.xy = float2(0.25,0.25) * r0.xy;
       r0.zw = -(r0.xy >= -r0.xy);
@@ -152,7 +144,7 @@ void main(
       r1.z = dot(cb0[19].xyzw, icb[r0.y+0].xyzw);
       r1.w = dot(cb0[20].xyzw, icb[r0.y+0].xyzw);
       r0.x = dot(r1.xyzw, icb[r0.x+0].xyzw);
-      r0.x = cb0[41].z * 17 + -r0.x;
+      r0.x = cb0[133].z * 17 + -r0.x;
       r0.x = -0.00999999978 + r0.x;
       r0.x = -(r0.x < 0);
       if (uncensor != 0.0){
@@ -160,17 +152,11 @@ void main(
       }
     }
   }
-  r0.x = t1.Sample(s0_s, v2.xy).w;
-  r0.y = -(cb0[39].x == 1.000000);
-  r0.x = -cb0[39].y + r0.x;
-  r0.x = -(r0.x < 0);
-  r0.x = r0.y ? r0.x : 0;
-  if (r0.x != 0) discard;
 //End Modesty
   float2 dims;
-  t69.GetDimensions(dims.x, dims.y);
-  mask.xyzw = t69.Load(uint3(++dims.xy*frac(v2.xy*0.99999),0)).xyzw;
-  //mask.xyzw = t69.Sample(s12_s, v2.xy).xyzw;
+  //t69.GetDimensions(dims.x, dims.y);
+  //mask.xyzw = t69.Load(uint3(++dims.xy*frac(v2.xy*0.99999),0)).xyzw;
+  mask.xyzw = t69.Sample(s0_s, v2.xy, int2(1,1)).xyzw;
   //if(mask.y == 0){
     if(mask.x == 0.0) discard;
     if(mask.x == 1.0) discard;
@@ -180,9 +166,14 @@ void main(
   ren2.xyzw = t72.Sample(s15_s, float2(v0.x/cb1[7].x, v0.y/cb1[7].y)).xyzw;
   // ren3.xyzw = t73.Sample(s15_s, float2(v0.x/cb1[7].x, v0.y/cb1[7].y)).xyzw;
   ren4.xyzw = t74.Sample(s15_s, float2(v0.x/cb1[7].x, v0.y/cb1[7].y)).xyzw;
-  normalmap.xyzw = t0.Sample(s0_s, v2.xy).xyzw;
-  diffuse.xyzw = t1.Sample(s1_s, v2.xy).xyzw;
-  lightmap.xyzw = t2.Sample(s2_s, v2.xy).xyzw;
+  // normalmap.xyzw = t0.Sample(s0_s, v2.xy, int2(1,1)).xyzw;
+  // //store normalmap.z for when I find out what it does.
+  // normalmap.w = normalmap.z;
+  // //unpack xy direction into xyz direction.
+  // normalmap.xy = normalmap.xy * 2 - 1;
+  // normalmap.z = sqrt(1-saturate(dot(normalmap.xy, normalmap.xy)));
+  diffuse.xyzw = t1.Sample(s0_s, v2.xy, int2(1,1)).xyzw;
+  lightmap.xyzw = t2.Sample(s1_s, v2.xy, int2(1,1)).xyzw;
 
   ren1 = ren1 + ren2 * 0.25;
   ren1 = clamp(ren1,0,1);
@@ -190,8 +181,7 @@ void main(
   //pray
   r0 = float4(0,0,0,0);
   r3 = float4(0,0,0,0); r4 = float4(0,0,0,0); r5 = float4(0,0,0,0); r6 = float4(0,0,0,0);
-  r0.x = -1 + 0.5;
-  r4.xyzw = t2.SampleBias(s1_s, v2.xy, r0.x).xyzw;
+  r4.xyzw = t2.Sample(s1_s, v2.xy, int2(1,1)).xyzw;
   r3.xy = float2(0,0);
   r0.x = 0;
   r5.xyzw = -(r4.wwww >= float4(0.800000012,0.400000006,0.200000003,0.600000024));
@@ -227,7 +217,7 @@ void main(
     r2.xyz = diffuse.xyz*0.5;
     r2.w = 0.0;
   }
-  
+  //r3.y = ren1.w > 0 ? lerp(0.223606795, ren1.w, (mask.y * intensity.y)) : 0.223606795;
   r3.y = mask.y > 0 ? mask.y * intensity.y : 0.223606795;
   r3.z = mask.z > 0 ? mask.z * intensity.z : 0.223606795;
   //r3.yz = float2(max(ren1.w,r3.y),max(ren4.x,r3.z));

--- a/hic_sunt_dracones/OutlineWithDiffuseColor1_5_3.hlsl
+++ b/hic_sunt_dracones/OutlineWithDiffuseColor1_5_3.hlsl
@@ -21,11 +21,10 @@ Texture2D<float4> t72 : register(t72);
 Texture2D<float4> t71 : register(t71);
 Texture2D<float4> t69 : register(t69);
 
-SamplerState s15_s {
-    Filter = MIN_MAG_MIP_LINEAR;
-    AddressU = wrap;
-    AddressV = wrap;
-};
+SamplerState s15_s : register(s15);
+SamplerState s14_s : register(s14);
+SamplerState s13_s : register(s13);
+SamplerState s12_s : register(s12);
 
 //
 
@@ -41,14 +40,19 @@ SamplerState s1_s : register(s1);
 
 SamplerState s0_s : register(s0);
 
+cbuffer cb2 : register(b2)
+{
+  float4 cb2[17];
+}
+
 cbuffer cb1 : register(b1)
 {
-  float4 cb1[8];
+  float4 cb1[10];
 }
 
 cbuffer cb0 : register(b0)
 {
-  float4 cb0[160];
+  float4 cb0[90];
 }
 
 // #MARK: --- HSV CODE ---
@@ -74,8 +78,8 @@ float3 hsv2rgb(float3 c)
 float3 adjust_hue(float3 HSV, float3 offset)
 {
 	if(HSV.x>=0.266f) HSV.x = fmod(HSV.x + offset.x, 1);
-  HSV.y += offset.y;
-  HSV.z += offset.z;
+  HSV.y *= offset.y;
+  HSV.z *= offset.z;
 	return HSV;
 }
 
@@ -92,13 +96,10 @@ void main(
   float4 v1 : COLOR0,
   float4 v2 : TEXCOORD0,
   float4 v3 : TEXCOORD1,
-  float4 v4 : TEXCOORD3,
-  float4 v5 : TEXCOORD4,
-  float4 v6 : TEXCOORD5,
-  float4 v7 : TEXCOORD6,
-  float4 v8 : TEXCOORD7,
-  float4 v9 : TEXCOORD8,
-  uint frontfacing : SV_IsFrontFace0,
+  float4 v4 : TEXCOORD2,
+  float4 v5 : TEXCOORD3,
+  float2 v6 : TEXCOORD4,
+  uint v7 : SV_IsFrontFace0,
   out float4 o0 : SV_Target0,
   out float4 o1 : SV_Target1,
   out float4 o2 : SV_Target2,
@@ -119,20 +120,26 @@ void main(
 
   r0 = float4(0,0,0,0);
   r1 = float4(0,0,0,0);
-  r0.x = -((int)frontfacing.x == 0);
+  r0.x = -((int)v7.x == 0);
   r0.y = r0.y ? r0.x : 0;
   r0.yz = r0.yy ? v2.zw : v2.xy;
-  texco = v6.xy;
+  texco = r0.yz;
 //Re-enable Modesty
-  r0.x = -(0 != cb0[133].y);
+  r1.xyz = v7.xxx ? v3.xyz : -v3.xyz;
+  r0.x = -(0 != cb0[36].y);
+  r0.y = -0.00999999978 + v1.w;
+  r0.y = -(r0.y < 0);
+  r0.x = r0.x ? r0.y : 0;
+  if (r0.x != 0) discard;
+  r0.x = -(0 != cb0[41].y);
   if (r0.x != 0) {
     if (uncensor == 2){
-      r0.x = -(cb0[133].z < 0.1);
+      r0.x = -(cb0[41].z < 0.1);
     }else{
-      r0.x = -(cb0[133].z < 0.949999988);
+      r0.x = -(cb0[41].z < 0.949999988);
     }
     if (r0.x != 0) {
-      r0.xy = v3.yx / v3.ww;
+      r0.xy = v4.yx / v4.ww;
       r0.xy = cb1[7].yx * r0.xy;
       r0.xy = float2(0.25,0.25) * r0.xy;
       r0.zw = -(r0.xy >= -r0.xy);
@@ -145,7 +152,7 @@ void main(
       r1.z = dot(cb0[19].xyzw, icb[r0.y+0].xyzw);
       r1.w = dot(cb0[20].xyzw, icb[r0.y+0].xyzw);
       r0.x = dot(r1.xyzw, icb[r0.x+0].xyzw);
-      r0.x = cb0[134].z * 17 + -r0.x;
+      r0.x = cb0[41].z * 17 + -r0.x;
       r0.x = -0.00999999978 + r0.x;
       r0.x = -(r0.x < 0);
       if (uncensor != 0.0){
@@ -153,31 +160,42 @@ void main(
       }
     }
   }
+  r0.x = t1.Sample(s0_s, v2.xy, int2(1,1)).w;
+  r0.y = -(cb0[39].x == 1.000000);
+  r0.x = -cb0[39].y + r0.x;
+  r0.x = -(r0.x < 0);
+  r0.x = r0.y ? r0.x : 0;
+  if (r0.x != 0) discard;
 //End Modesty
   float2 dims;
   //t69.GetDimensions(dims.x, dims.y);
-  //mask.xyzw = t69.Load(uint3(++dims.xy*frac(texco*0.99999),0)).xyzw;
-  mask.xyzw = t69.Sample(s15_s, texco).xyzw;
+  //mask.xyzw = t69.Load(uint3(++dims.xy*frac(v2.xy*0.99999),0)).xyzw;
+  mask.xyzw = t69.Sample(s0_s, v2.xy, int2(1,1)).xyzw;
   //if(mask.y == 0){
     if(mask.x == 0.0) discard;
-    if(mask.x == 1.0) discard; 
-    
+    if(mask.x == 1.0) discard;
   //}
 
   ren1.xyzw = t71.Sample(s15_s, float2(v0.x/cb1[7].x, v0.y/cb1[7].y)).xyzw;
   ren2.xyzw = t72.Sample(s15_s, float2(v0.x/cb1[7].x, v0.y/cb1[7].y)).xyzw;
   // ren3.xyzw = t73.Sample(s15_s, float2(v0.x/cb1[7].x, v0.y/cb1[7].y)).xyzw;
-  ren4.xyzw = t74.Sample(s15_s, float2(v0.x/cb1[7].x, v0.y/cb1[7].y)).xxxx;
-  diffuse.xyzw = t0.Sample(s15_s, texco).xyzw;
-  lightmap.xyzw = t1.Sample(s15_s, texco).xyzw;
+  ren4.xyzw = t74.Sample(s15_s, float2(v0.x/cb1[7].x, v0.y/cb1[7].y)).xyzw;
+  normalmap.xyzw = t0.Sample(s0_s, v2.xy, int2(1,1)).xyzw;
+  //store normalmap.z for when I find out what it does.
+  normalmap.w = normalmap.z;
+  //unpack xy direction into xyz direction.
+  normalmap.xy = normalmap.xy * 2 - 1;
+  normalmap.z = sqrt(1-saturate(dot(normalmap.xy, normalmap.xy)));
+  diffuse.xyzw = t1.Sample(s0_s, v2.xy, int2(1,1)).xyzw;
+  lightmap.xyzw = t2.Sample(s1_s, v2.xy, int2(1,1)).xyzw;
 
-  // ren1 = ren1 + ren2 * 0.25;
-  // ren1 = clamp(ren1,0,1);
-
+  ren1 = ren1 + ren2 * 0.25;
+  ren1 = clamp(ren1,0,1);
+  
   //pray
   r0 = float4(0,0,0,0);
   r3 = float4(0,0,0,0); r4 = float4(0,0,0,0); r5 = float4(0,0,0,0); r6 = float4(0,0,0,0);
-  r4.xyzw = t1.Sample(s15_s, texco).xyzw;
+  r4.xyzw = t2.Sample(s1_s, v2.xy, int2(1,1)).xyzw;
   r3.xy = float2(0,0);
   r0.x = 0;
   r5.xyzw = -(r4.wwww >= float4(0.800000012,0.400000006,0.200000003,0.600000024));
@@ -213,18 +231,6 @@ void main(
     r2.xyz = diffuse.xyz*0.5;
     r2.w = 0.0;
   }
-  if(ren2.x > 0.0 || ren2.y > 0.0 || ren2.z > 0.0){
-    // Replace Diffuse here with some YUV value
-    r4.xyzw = float4(
-      lerp(diffuse.x, ren2.x, mask.x),
-      lerp(diffuse.y, ren2.y, mask.x),
-      lerp(diffuse.z, ren2.z, mask.x),
-      0.0
-    );
-  }else{
-    r4.xyz = diffuse.xyz*0.5;
-    r4.w = 0.0;
-  }
   //r3.y = ren1.w > 0 ? lerp(0.223606795, ren1.w, (mask.y * intensity.y)) : 0.223606795;
   r3.y = mask.y > 0 ? mask.y * intensity.y : 0.223606795;
   r3.z = mask.z > 0 ? mask.z * intensity.z : 0.223606795;
@@ -233,7 +239,7 @@ void main(
   o0.w = r5.x ? 0.333000 : 0;
   o1.xyz = r2.xyz;
   o1.w = r3.y;
-  o2.xyz = r4.xyz;
+  o2.xyz = r2.xyz;
   o2.w = 1.0;
   o3.x = 0.0;
   o4.x = r3.z;
@@ -242,9 +248,3 @@ void main(
   return;
 }
 #endif
-
-// v2 is probably the object normal
-// v3 is ?
-// v4 is probably the view normal
-// v5
-// v6


### PR DESCRIPTION
## Version 1.054
### Fixes
- Repaired Existing Features
- Could not repair censorship correctly
- Now defaults to uncensored until a solution is made.
- Natlan characters seem to be functional, didn't test all cases.

### Known issues
- Some transparencies will not work properly as the characters load in.
- This also affects custom outline colors, will look for a solution. (LOD Shaders)
- Intel Integrated graphics glow effects are still malfunctioning, will look into it.